### PR TITLE
Enforce hermetic pre-build script tasks

### DIFF
--- a/acceptance/samples/policy-input-golden-container.json
+++ b/acceptance/samples/policy-input-golden-container.json
@@ -887,7 +887,8 @@
                     ],
                     "IMAGE_EXPIRES_AFTER": "",
                     "STORAGE_DRIVER": "vfs",
-                    "TLSVERIFY": "true"
+                    "TLSVERIFY": "true",
+                    "HERMETIC": "true"
                   }
                 },
                 "name": "build-container",
@@ -1037,7 +1038,8 @@
                   },
                   "parameters": {
                     "BASE_IMAGES": "",
-                    "BINARY_IMAGE": "quay.io/redhat-user-workloads/rhtap-contract-tenant/golden-container/golden-container:d11c0ada39f18f631ff4f54beafa72a9b62dcd7c"
+                    "BINARY_IMAGE": "quay.io/redhat-user-workloads/rhtap-contract-tenant/golden-container/golden-container:d11c0ada39f18f631ff4f54beafa72a9b62dcd7c",
+                    "HERMETIC": "true"
                   }
                 },
                 "name": "build-source-image",

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -136,6 +136,7 @@ Rules included:
 * xref:release_policy.adoc#olm__unmapped_references[OLM: Unmapped images in OLM bundle]
 * xref:release_policy.adoc#olm__unpinned_references[OLM: Unpinned images in OLM bundle]
 * xref:release_policy.adoc#olm__unpinned_snapshot_references[OLM: Unpinned images in input snapshot]
+* xref:release_policy.adoc#pre_build_script__pre_build_script_hermetic[Pre-build-script task checks: Pre-Build-Script task called with hermetic param set]
 * xref:release_policy.adoc#provenance_materials__git_clone_source_matches_provenance[Provenance Materials: Git clone source matches materials provenance]
 * xref:release_policy.adoc#provenance_materials__git_clone_task_found[Provenance Materials: Git clone task found]
 * xref:release_policy.adoc#quay_expiration__expires_label[Quay expiration: Expires label]
@@ -980,6 +981,25 @@ Check the input snapshot for the presence of unpinned image references. Unpinned
 * Code: `olm.unpinned_snapshot_references`
 * Effective from: `2024-08-15T00:00:00Z`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L126[Source, window="_blank"]
+
+[#pre_build_script_package]
+== link:#pre_build_script_package[Pre-build-script task checks]
+
+This package verifies that the pre-build-script task in the attestation is run in a controlled environment: it must be hermetic, and running in an allowed image)
+
+* Package name: `pre_build_script`
+
+[#pre_build_script__pre_build_script_hermetic]
+=== link:#pre_build_script__pre_build_script_hermetic[Pre-Build-Script task called with hermetic param set]
+
+Verify the pre-build-script task (run-script-oci-ta) in the PipelineRun	attestation was invoked with the proper parameters to make the pre-build script execution hermetic.
+
+*Solution*: Make sure that the pre-build-script task (run-script-oci-ta) has a parameter named 'HERMETIC' and it's set to 'true'.
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `Pre-Build-Script task was not invoked with the hermetic parameter set: '%s'`
+* Code: `pre_build_script.pre_build_script_hermetic`
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/pre_build_script/pre_build_script.rego#L16[Source, window="_blank"]
 
 [#provenance_materials_package]
 == link:#provenance_materials_package[Provenance Materials]

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -706,7 +706,7 @@ Verify the build task in the PipelineRun attestation was invoked with the proper
 *Solution*: Make sure the task that builds the image has a parameter named 'HERMETIC' and it's set to 'true'.
 
 * Rule type: [rule-type-indicator failure]#FAILURE#
-* FAILURE message: `Build task was not invoked with the hermetic parameter set`
+* FAILURE message: `Build task was not invoked with the hermetic parameter set: '%s'`
 * Code: `hermetic_build_task.build_task_hermetic`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/hermetic_build_task/hermetic_build_task.rego#L15[Source, window="_blank"]
 

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -66,6 +66,8 @@
 **** xref:release_policy.adoc#olm__unmapped_references[Unmapped images in OLM bundle]
 **** xref:release_policy.adoc#olm__unpinned_references[Unpinned images in OLM bundle]
 **** xref:release_policy.adoc#olm__unpinned_snapshot_references[Unpinned images in input snapshot]
+*** xref:release_policy.adoc#pre_build_script_package[Pre-build-script task checks]
+**** xref:release_policy.adoc#pre_build_script__pre_build_script_hermetic[Pre-Build-Script task called with hermetic param set]
 *** xref:release_policy.adoc#provenance_materials_package[Provenance Materials]
 **** xref:release_policy.adoc#provenance_materials__git_clone_source_matches_provenance[Git clone source matches materials provenance]
 **** xref:release_policy.adoc#provenance_materials__git_clone_task_found[Git clone task found]

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -18,6 +18,8 @@ latest_required_default_tasks := ectime.newest(data["required-tasks"])
 # The set of required tasks that are required right now.
 current_required_default_tasks := ectime.most_current(data["required-tasks"])
 
+_pre_build_script_task_name := "run-script-oci-ta"
+
 # tasks returns the set of tasks found in the object.
 tasks(obj) := {task |
 	some task in _maybe_tasks(obj)
@@ -131,6 +133,11 @@ task_params(task) := params if {
 # task_param returns the value of the given parameter in the task.
 task_param(task, name) := task_params(task)[name]
 
+task_is_hermetic(task) if {
+	task_param(task, "HERMETIC")
+	task_param(task, "HERMETIC") == "true"
+}
+
 # slsa v0.2 results
 task_results(task) := task.results
 
@@ -169,6 +176,11 @@ build_tasks(attestation) := [task |
 
 	image_digest := task_result_artifact_digest(task)
 	count(image_digest) > 0
+]
+
+pre_build_script_tasks(attestation) := [task |
+	some task in tasks(attestation)
+	task_name(task) == _pre_build_script_task_name
 ]
 
 # return the tasks that have "TEST_OUTPUT" as a result

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -162,6 +162,36 @@ test_task_slsav1_param if {
 	not tekton.task_param(task, "missing")
 }
 
+test_task_is_hermetic if {
+	task_hermetic := {
+		"kind": "TaskRun",
+		"metadata": {"name": "some-task"},
+		"spec": {"params": [{"name": "HERMETIC", "value": "true"}]},
+	}
+	tekton.task_is_hermetic(task_hermetic)
+
+	task_not_hermetic := {
+		"kind": "TaskRun",
+		"metadata": {"name": "some-task"},
+		"spec": {"params": [{"name": "HERMETIC", "value": "false"}]},
+	}
+	not tekton.task_is_hermetic(task_not_hermetic)
+
+	task_invalid_hermetic_param = {
+		"kind": "TaskRun",
+		"metadata": {"name": "some-task"},
+		"spec": {"params": [{"name": "HERMETIC", "value": "not a valid value"}]},
+	}
+	not tekton.task_is_hermetic(task_invalid_hermetic_param)
+
+	task_hermetic_param_not_present = {
+		"kind": "TaskRun",
+		"metadata": {"name": "some-task"},
+		"spec": {"params": [{"name": "OTHERPARAM", "value": "other-value"}]},
+	}
+	not tekton.task_is_hermetic(task_hermetic_param_not_present)
+}
+
 test_task_result if {
 	task := {"results": [{"name": "SPAM", "value": "maps"}]}
 	lib.assert_equal("maps", tekton.task_result(task, "SPAM"))

--- a/policy/release/hermetic_build_task/hermetic_build_task_test.rego
+++ b/policy/release/hermetic_build_task/hermetic_build_task_test.rego
@@ -12,7 +12,7 @@ test_hermetic_build if {
 test_not_hermetic_build if {
 	expected := {{
 		"code": "hermetic_build_task.build_task_hermetic",
-		"msg": "Build task was not invoked with the hermetic parameter set",
+		"msg": "Build task was not invoked with the hermetic parameter set: 'any-task'",
 	}}
 
 	hermetic_not_true := json.patch(_good_attestation, [{
@@ -63,11 +63,13 @@ test_hermetic_build_many_build_tasks if {
 			"value": "false",
 		}],
 	)
-	expected := {{
+	expected_mixed_hermetic := {{
 		"code": "hermetic_build_task.build_task_hermetic",
-		"msg": "Build task was not invoked with the hermetic parameter set",
+		"msg": "Build task was not invoked with the hermetic parameter set: 'build-1'",
 	}}
-	lib.assert_equal_results(expected, hermetic_build_task.deny) with input.attestations as [attestation_mixed_hermetic]
+
+	# regal ignore:line-length
+	lib.assert_equal_results(expected_mixed_hermetic, hermetic_build_task.deny) with input.attestations as [attestation_mixed_hermetic]
 
 	attestation_non_hermetic := json.patch(
 		{"statement": {"predicate": {
@@ -87,7 +89,19 @@ test_hermetic_build_many_build_tasks if {
 			},
 		],
 	)
-	lib.assert_equal_results(expected, hermetic_build_task.deny) with input.attestations as [attestation_non_hermetic]
+	expected_non_hermetic := {
+		{
+			"code": "hermetic_build_task.build_task_hermetic",
+			"msg": "Build task was not invoked with the hermetic parameter set: 'build-1'",
+		},
+		{
+			"code": "hermetic_build_task.build_task_hermetic",
+			"msg": "Build task was not invoked with the hermetic parameter set: 'build-2'",
+		},
+	}
+
+	# regal ignore:line-length
+	lib.assert_equal_results(expected_non_hermetic, hermetic_build_task.deny) with input.attestations as [attestation_non_hermetic]
 }
 
 _good_attestation := {"statement": {"predicate": {

--- a/policy/release/pre_build_script/pre_build_script.rego
+++ b/policy/release/pre_build_script/pre_build_script.rego
@@ -1,0 +1,44 @@
+#
+# METADATA
+# title: Pre-build-script task checks
+# description: >-
+#   This package verifies that the pre-build-script task in the
+#   attestation is run in a controlled environment: it must be
+#   hermetic, and running in an allowed image)
+#
+package pre_build_script
+
+import rego.v1
+
+import data.lib
+import data.lib.tekton
+
+# METADATA
+# title: Pre-Build-Script task called with hermetic param set
+# description: >-
+#   Verify the pre-build-script task (run-script-oci-ta) in the
+#   PipelineRun	attestation was invoked with the proper parameters to
+#   make the pre-build script execution hermetic.
+# custom:
+#   short_name: pre_build_script_hermetic
+#   failure_msg: >-
+#     Pre-Build-Script task was not invoked with
+#     the hermetic parameter set: '%s'
+#   solution: >-
+#     Make sure that the pre-build-script task (run-script-oci-ta) has
+#     a parameter named 'HERMETIC' and it's set to 'true'.
+#   collections:
+#   - redhat
+#   depends_on:
+#   - attestation_type.known_attestation_type
+#
+deny contains result if {
+	some not_hermetic_script_task in _hermetic_pre_build_scripts
+	result := lib.result_helper(rego.metadata.chain(), [tekton.task_name(not_hermetic_script_task)])
+}
+
+_hermetic_pre_build_scripts contains task if {
+	some attestation in lib.pipelinerun_attestations
+	some task in tekton.pre_build_script_tasks(attestation)
+	not tekton.task_is_hermetic(task)
+}

--- a/policy/release/pre_build_script/pre_build_script_test.rego
+++ b/policy/release/pre_build_script/pre_build_script_test.rego
@@ -1,0 +1,66 @@
+package pre_build_script_test
+
+import rego.v1
+
+import data.lib
+import data.pre_build_script
+
+test_good_pre_build_scripts if {
+	lib.assert_empty(pre_build_script.deny) with input.attestations as [_good_attestation]
+}
+
+test_not_hermetic_pre_build_scripts if {
+	expected := {{
+		"code": "pre_build_script.pre_build_script_hermetic",
+		# regal ignore:line-length
+		"msg": "Pre-Build-Script task was not invoked with the hermetic parameter set: 'run-script-oci-ta'",
+	}}
+
+	hermetic_not_true := json.patch(_good_attestation, [{
+		"op": "add",
+		"path": "/statement/predicate/buildConfig/tasks/0/invocation/parameters/HERMETIC",
+		"value": "false",
+	}])
+	lib.assert_equal_results(expected, pre_build_script.deny) with input.attestations as [hermetic_not_true]
+
+	hermetic_invalid := json.patch(_good_attestation, [{
+		"op": "add",
+		"path": "/statement/predicate/buildConfig/tasks/0/invocation/parameters/HERMETIC",
+		"value": "something else",
+	}])
+	lib.assert_equal_results(expected, pre_build_script.deny) with input.attestations as [hermetic_invalid]
+
+	# regal ignore:line-length
+	hermetic_missing := json.remove(_good_attestation, ["/statement/predicate/buildConfig/tasks/0/invocation/parameters/HERMETIC"])
+	lib.assert_equal_results(expected, pre_build_script.deny) with input.attestations as [hermetic_missing]
+}
+
+_good_attestation := {"statement": {"predicate": {
+	"buildType": lib.tekton_pipeline_run,
+	"buildConfig": {"tasks": [
+		{
+			"name": "run-script-oci-ta-1",
+			"ref": {"kind": "Task", "name": "run-script-oci-ta", "bundle": "reg.img/spam@sha256:abc"},
+			"invocation": {"parameters": {"HERMETIC": "true", "SCRIPT": "/some-script.sh"}},
+		},
+		{
+			"name": "run-script-oci-ta-2",
+			"ref": {"kind": "Task", "name": "run-script-oci-ta", "bundle": "reg.img/spam@sha256:def"},
+			"invocation": {"parameters": {"HERMETIC": "true", "SCRIPT": "/some-other-script.sh"}},
+		},
+		{
+			"name": "prefetch-dependencies",
+			"ref": {"kind": "Task", "name": "prefetch-dependencies", "bundle": "reg.img/spam@sha256:abc"},
+			"invocation": {"parameters": {}},
+		},
+		{
+			"after": ["run-script-oci-ta-1", "run-script-oci-ta-2", "prefetch-dependencies"],
+			"results": [
+				{"name": "IMAGE_URL", "value": "registry/repo"},
+				{"name": "IMAGE_DIGEST", "value": "digest"},
+			],
+			"ref": {"kind": "Task", "name": "any-task", "bundle": "reg.img/spam@sha256:abc"},
+			"invocation": {"parameters": {"HERMETIC": "true"}},
+		},
+	]},
+}}}


### PR DESCRIPTION
Verify that, if one or more pre-build script tasks (run-script-oci-ta) are found in the PipelineRun, they have been executed in an hermetic environment.

This ensures that no unverified source code or dependencies will end up in the generated image.
    
Ref: https://issues.redhat.com/browse/EC-1243