### PR TITLE
chore: update references to ec-policies repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
       time: '15:00'
       timezone: Etc/UTC
   - package-ecosystem: "npm"
-    directory: "/antora/ec-policies-antora-extension"
+    directory: "/antora/policy-antora-extension"
     schedule:
       interval: weekly
       time: '15:00'

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ annotations-opa:
 SHORT_SHA=$(shell git rev-parse --short HEAD)
 
 generate-docs:  ## Generate static docs
-	@cd docs && go run github.com/enterprise-contract/ec-policies/docs -adoc ../antora/docs/modules/ROOT -rego .. -rego "$$(go list -modfile ../go.mod -f '{{.Dir}}' github.com/enterprise-contract/ec-cli)/docs/policy/release"
+	@cd docs && go run github.com/conforma/policy/docs -adoc ../antora/docs/modules/ROOT -rego .. -rego "$$(go list -modfile ../go.mod -f '{{.Dir}}' github.com/enterprise-contract/ec-cli)/docs/policy/release"
 
 ##@ CI
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ec-policies
+# policy
 
 [Rego][rego] policies related to the Conforma.
 
@@ -123,8 +123,8 @@ Create a `policy.yaml` file in your local `ec-cli` repo with something like:
     ---
     sources:
       - policy:
-          - <path-to>/ec-policies/policy/lib
-          - <path-to>/ec-policies/policy/release
+          - <path-to>/policy/policy/lib
+          - <path-to>/policy/policy/release
         data:
           - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
           - github.com/release-engineering/rhtap-ec-policy//data
@@ -165,13 +165,13 @@ contributing to the definition of policy rules.
 [entr]: https://github.com/eradman/entr
 [testing]: https://www.openpolicyagent.org/docs/latest/policy-testing/
 [docs]: https://conforma.dev/
-[policydocs]: https://conforma.dev/docs/ec-policies/release_policy.html
+[policydocs]: https://conforma.dev/docs/policy/release_policy.html
 [taskdef]: https://github.com/enterprise-contract/ec-cli/blob/main/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
 [contract]: https://github.com/enterprise-contract
 [ec-cli]: https://github.com/enterprise-contract/ec-cli
 [konflux-ci]: https://github.com/konflux-ci
 [builddefs]: https://github.com/konflux-ci/build-definitions
-[authoring]: https://conforma.dev/docs/ec-policies/authoring.html
+[authoring]: https://conforma.dev/docs/policy/authoring.html
 [antora]: https://docs.antora.org/antora/latest/install-and-run-quickstart/
 [quay]: https://quay.io/
 [infradeployments]: https://github.com/redhat-appstudio/infra-deployments

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -291,7 +291,7 @@ func replaceVariables(content string, variables map[string]string) string {
 }
 
 func setupScenario(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
-	tempDir, err := os.MkdirTemp("", "ec-policies-")
+	tempDir, err := os.MkdirTemp("", "policy-")
 	if err != nil {
 		return ctx, fmt.Errorf("setting up scenario: %w", err)
 	}

--- a/acceptance/go.mod
+++ b/acceptance/go.mod
@@ -1,4 +1,4 @@
-module github.com/enterprise-contract/ec-policies/acceptance
+module github.com/conforma/policy/acceptance
 
 go 1.23.6
 

--- a/antora/docs/antora.yml
+++ b/antora/docs/antora.yml
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: ec-policies
+name: policy
 title: Conforma Policies
 version: ~
 nav:

--- a/antora/docs/modules/ROOT/pages/build_task_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/build_task_policy.adoc
@@ -19,7 +19,7 @@ Confirm the build task definition has the required build type label.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The required build label '%s' is missing`
 * Code: `build_labels.build_type_label_set`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/build_task/build_labels/build_labels.rego#L17[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/build_task/build_labels/build_labels.rego#L17[Source, window="_blank"]
 
 [#build_labels__build_task_has_label]
 === link:#build_labels__build_task_has_label[Build task has label]
@@ -29,4 +29,4 @@ Confirm that the build task definition includes at least one label.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The task definition does not include any labels`
 * Code: `build_labels.build_task_has_label`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/build_task/build_labels/build_labels.rego#L30[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/build_task/build_labels/build_labels.rego#L30[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/index.adoc
+++ b/antora/docs/modules/ROOT/pages/index.adoc
@@ -18,7 +18,7 @@ xref:pipeline_policy.adoc[Pipeline Policy].
 
 == Code
 
-* https://github.com/enterprise-contract/ec-policies[github.com/enterprise-contract/ec-policies]
+* https://github.com/conforma/plicy[github.com/conforma/policy]
 * https://github.com/enterprise-contract/ec-cli[github.com/enterprise-contract/ec-cli]
 * https://github.com/enterprise-contract[github.com/enterprise-contract]
 * https://github.com/konflux-ci[github.com/konflux-ci]

--- a/antora/docs/modules/ROOT/pages/pipeline_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/pipeline_policy.adoc
@@ -19,7 +19,7 @@ Confirm the `trusted_tasks` rule data was provided, since it's required by the p
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Missing required trusted_tasks data`
 * Code: `task_bundle.missing_required_data`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L94[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L94[Source, window="_blank"]
 
 [#task_bundle__untrusted_task_bundle]
 === link:#task_bundle__untrusted_task_bundle[Task bundle is not trusted]
@@ -29,7 +29,7 @@ For each Task in the Pipeline definition, check if the Tekton Bundle used is a t
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Pipeline task '%s' uses an untrusted task bundle '%s'`
 * Code: `task_bundle.untrusted_task_bundle`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L79[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L79[Source, window="_blank"]
 
 [#task_bundle__out_of_date_task_bundle]
 === link:#task_bundle__out_of_date_task_bundle[Task bundle is out of date]
@@ -39,7 +39,7 @@ For each Task in the Pipeline definition, check if the Tekton Bundle used is the
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Pipeline task '%s' uses an out of date task bundle '%s', new version of the Task must be used before %s`
 * Code: `task_bundle.out_of_date_task_bundle`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L34[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L34[Source, window="_blank"]
 
 [#task_bundle__empty_task_bundle_reference]
 === link:#task_bundle__empty_task_bundle_reference[Task bundle reference is empty]
@@ -49,7 +49,7 @@ Check that a valid task bundle reference is being used.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Pipeline task '%s' uses an empty bundle image reference`
 * Code: `task_bundle.empty_task_bundle_reference`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L66[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L66[Source, window="_blank"]
 
 [#task_bundle__disallowed_task_reference]
 === link:#task_bundle__disallowed_task_reference[Task bundle was not used or is not defined]
@@ -59,7 +59,7 @@ Check for the existence of a task bundle. This rule will fail if the task is not
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Pipeline task '%s' does not contain a bundle reference`
 * Code: `task_bundle.disallowed_task_reference`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L52[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L52[Source, window="_blank"]
 
 [#task_bundle__unpinned_task_bundle]
 === link:#task_bundle__unpinned_task_bundle[Unpinned task bundle reference]
@@ -69,7 +69,7 @@ Check if the Tekton Bundle used for the Tasks in the Pipeline definition is pinn
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Pipeline task '%s' uses an unpinned task bundle reference '%s'`
 * Code: `task_bundle.unpinned_task_bundle`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L20[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/task_bundle/task_bundle.rego#L20[Source, window="_blank"]
 
 [#basic_package]
 == link:#basic_package[Pipeline definition sanity checks]
@@ -86,7 +86,7 @@ Confirm that the pipeline definition has the kind "Pipeline".
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Unexpected kind '%s' for pipeline definition`
 * Code: `basic.expected_kind`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/basic/basic.rego#L19[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/basic/basic.rego#L19[Source, window="_blank"]
 
 [#required_tasks_package]
 == link:#required_tasks_package[Required tasks]
@@ -103,7 +103,7 @@ Produce a warning when a task that will be required in the future is not current
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `%s is missing and will be required on %s`
 * Code: `required_tasks.missing_future_required_task`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/required_tasks/required_tasks.rego#L35[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/required_tasks/required_tasks.rego#L35[Source, window="_blank"]
 
 [#required_tasks__missing_required_task]
 === link:#required_tasks__missing_required_task[Missing required task]
@@ -113,7 +113,7 @@ Ensure that the set of required tasks is included in the Pipeline definition.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s is missing or outdated`
 * Code: `required_tasks.missing_required_task`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/required_tasks/required_tasks.rego#L72[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/required_tasks/required_tasks.rego#L72[Source, window="_blank"]
 
 [#required_tasks__tasks_found]
 === link:#required_tasks__tasks_found[Pipeline contains tasks]
@@ -123,7 +123,7 @@ Confirm at least one task is present in the pipeline definition.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `No tasks found in pipeline`
 * Code: `required_tasks.tasks_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/required_tasks/required_tasks.rego#L59[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/required_tasks/required_tasks.rego#L59[Source, window="_blank"]
 
 [#required_tasks__required_tasks_list_present]
 === link:#required_tasks__required_tasks_list_present[Required task list is present in rule data]
@@ -133,7 +133,7 @@ Confirm the `required-tasks` rule data was provided, since it's required by the 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The required tasks list is missing from the rule data`
 * Code: `required_tasks.required_tasks_list_present`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/required_tasks/required_tasks.rego#L91[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/required_tasks/required_tasks.rego#L91[Source, window="_blank"]
 
 [#required_tasks__required_tasks_found]
 === link:#required_tasks__required_tasks_found[Required tasks found in pipeline definition]
@@ -143,4 +143,4 @@ Produce a warning if a list of current or future required tasks does not exist i
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Required tasks do not exist for pipeline %q`
 * Code: `required_tasks.required_tasks_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/pipeline/required_tasks/required_tasks.rego#L16[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/pipeline/required_tasks/required_tasks.rego#L16[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/policy_bundles.adoc
+++ b/antora/docs/modules/ROOT/pages/policy_bundles.adoc
@@ -12,15 +12,15 @@ The latest versions of the bundles can be found in the following repos:
 https://quay.io/repository/enterprise-contract/ec-release-policy?tab=tags[`quay.io/enterprise-contract/ec-release-policy`]::
 
 Used for validating attestations created by Tekton Chains. Contains the
-contents of https://github.com/enterprise-contract/ec-policies/tree/main/policy/release[`policy/release`]
-and https://github.com/enterprise-contract/ec-policies/tree/main/policy/lib[`policy/lib`]
+contents of https://github.com/conforma/policy/tree/main/policy/release[`policy/release`]
+and https://github.com/conforma/policy/tree/main/policy/lib[`policy/lib`]
 in this repo.
 
 https://quay.io/repository/enterprise-contract/ec-pipeline-policy?tab=tags[`quay.io/enterprise-contract/ec-pipeline-policy`]::
 
 Used for validating Tekton Pipeline definitions. Contains the contents of
-https://github.com/enterprise-contract/ec-policies/tree/main/policy/pipeline[`policy/pipeline`]
-and https://github.com/enterprise-contract/ec-policies/tree/main/policy/lib[`policy/lib`].
+https://github.com/conforma/policy/tree/main/policy/pipeline[`policy/pipeline`]
+and https://github.com/conforma/policy/tree/main/policy/lib[`policy/lib`].
 
 == Artifact Hub entries
 

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -332,7 +332,7 @@ The Conforma CLI now places the attestation data in a different location. This c
 * FAILURE message: `Deprecated policy attestation format found`
 * Code: `attestation_type.deprecated_policy_attestation_format`
 * Effective from: `2023-08-31T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/attestation_type/attestation_type.rego#L78[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/attestation_type/attestation_type.rego#L78[Source, window="_blank"]
 
 [#attestation_type__known_attestation_type]
 === link:#attestation_type__known_attestation_type[Known attestation type found]
@@ -344,7 +344,7 @@ Confirm the attestation found for the image has a known attestation type.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Unknown attestation type '%s'`
 * Code: `attestation_type.known_attestation_type`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/attestation_type/attestation_type.rego#L14[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/attestation_type/attestation_type.rego#L14[Source, window="_blank"]
 
 [#attestation_type__known_attestation_types_provided]
 === link:#attestation_type__known_attestation_types_provided[Known attestation types provided]
@@ -356,7 +356,7 @@ Confirm the `known_attestation_types` rule data was provided.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `attestation_type.known_attestation_types_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/attestation_type/attestation_type.rego#L41[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/attestation_type/attestation_type.rego#L41[Source, window="_blank"]
 
 [#attestation_type__pipelinerun_attestation_found]
 === link:#attestation_type__pipelinerun_attestation_found[PipelineRun attestation found]
@@ -368,7 +368,7 @@ Confirm at least one PipelineRun attestation is present.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Missing pipelinerun attestation`
 * Code: `attestation_type.pipelinerun_attestation_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/attestation_type/attestation_type.rego#L59[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/attestation_type/attestation_type.rego#L59[Source, window="_blank"]
 
 [#base_image_registries_package]
 == link:#base_image_registries_package[Base image checks]
@@ -387,7 +387,7 @@ Confirm the `allowed_registry_prefixes` rule data was provided, since it's requi
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `base_image_registries.allowed_registries_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L78[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L78[Source, window="_blank"]
 
 [#base_image_registries__base_image_permitted]
 === link:#base_image_registries__base_image_permitted[Base image comes from permitted registry]
@@ -399,7 +399,7 @@ Verify that the base images used when building a container image come from a kno
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Base image %q is from a disallowed registry`
 * Code: `base_image_registries.base_image_permitted`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L18[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L18[Source, window="_blank"]
 
 [#base_image_registries__base_image_info_found]
 === link:#base_image_registries__base_image_info_found[Base images provided]
@@ -411,7 +411,7 @@ Verify the expected information was provided about which base images were used d
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Base images information is missing`
 * Code: `base_image_registries.base_image_info_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L48[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/base_image_registries/base_image_registries.rego#L48[Source, window="_blank"]
 
 [#buildah_build_task_package]
 == link:#buildah_build_task_package[Buildah build task]
@@ -431,7 +431,7 @@ Verify the ADD_CAPABILITIES parameter of a builder Tasks was not used.
 * FAILURE message: `ADD_CAPABILITIES parameter is not allowed`
 * Code: `buildah_build_task.add_capabilities_param`
 * Effective from: `2024-08-31T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L35[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L35[Source, window="_blank"]
 
 [#buildah_build_task__buildah_uses_local_dockerfile]
 === link:#buildah_build_task__buildah_uses_local_dockerfile[Buildah task uses a local Dockerfile]
@@ -443,7 +443,7 @@ Verify the Dockerfile used in the buildah task was not fetched from an external 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `DOCKERFILE param value (%s) is an external source`
 * Code: `buildah_build_task.buildah_uses_local_dockerfile`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L14[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L14[Source, window="_blank"]
 
 [#buildah_build_task__platform_param]
 === link:#buildah_build_task__platform_param[PLATFORM parameter]
@@ -456,7 +456,7 @@ Verify the value of the PLATFORM parameter of a builder Task is allowed by match
 * FAILURE message: `PLATFORM parameter value %q is disallowed by regex %q`
 * Code: `buildah_build_task.platform_param`
 * Effective from: `2024-09-01T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L58[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L58[Source, window="_blank"]
 
 [#buildah_build_task__privileged_nested_param]
 === link:#buildah_build_task__privileged_nested_param[PRIVILEGED_NESTED parameter]
@@ -468,7 +468,7 @@ Verify the PRIVILEGED_NESTED parameter of a builder Tasks was not set to `true`.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `setting PRIVILEGED_NESTED parameter to true is not allowed`
 * Code: `buildah_build_task.privileged_nested_param`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L97[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L97[Source, window="_blank"]
 
 [#buildah_build_task__disallowed_platform_patterns_pattern]
 === link:#buildah_build_task__disallowed_platform_patterns_pattern[disallowed_platform_patterns format]
@@ -478,7 +478,7 @@ Confirm the `disallowed_platform_patterns` rule data, if provided matches the ex
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `buildah_build_task.disallowed_platform_patterns_pattern`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L81[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/buildah_build_task/buildah_build_task.rego#L81[Source, window="_blank"]
 
 [#cve_package]
 == link:#cve_package[CVE checks]
@@ -520,7 +520,7 @@ The SLSA Provenance attestation for the image is inspected to ensure CVEs that h
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Found %q vulnerability of %s security level`
 * Code: `cve.cve_blockers`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L114[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L114[Source, window="_blank"]
 
 [#cve__unpatched_cve_blockers]
 === link:#cve__unpatched_cve_blockers[Blocking unpatched CVE check]
@@ -532,7 +532,7 @@ The SLSA Provenance attestation for the image is inspected to ensure CVEs that d
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Found %q unpatched vulnerability of %s security level`
 * Code: `cve.unpatched_cve_blockers`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L148[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L148[Source, window="_blank"]
 
 [#cve__cve_results_found]
 === link:#cve__cve_results_found[CVE scan results found]
@@ -544,7 +544,7 @@ Confirm that clair-scan task results are present in the SLSA Provenance attestat
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Clair CVE scan results were not found`
 * Code: `cve.cve_results_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L185[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L185[Source, window="_blank"]
 
 [#cve__cve_warnings]
 === link:#cve__cve_warnings[Non-blocking CVE check]
@@ -556,7 +556,7 @@ The SLSA Provenance attestation for the image is inspected to ensure CVEs that h
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Found %q non-blocking vulnerability of %s security level`
 * Code: `cve.cve_warnings`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L58[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L58[Source, window="_blank"]
 
 [#cve__unpatched_cve_warnings]
 === link:#cve__unpatched_cve_warnings[Non-blocking unpatched CVE check]
@@ -568,7 +568,7 @@ The SLSA Provenance attestation for the image is inspected to ensure CVEs that d
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Found %q non-blocking unpatched vulnerability of %s security level`
 * Code: `cve.unpatched_cve_warnings`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L86[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L86[Source, window="_blank"]
 
 [#cve__rule_data_provided]
 === link:#cve__rule_data_provided[Rule data provided]
@@ -580,7 +580,7 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `cve.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L211[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/cve/cve.rego#L211[Source, window="_blank"]
 
 [#external_parameters_package]
 == link:#external_parameters_package[External parameters]
@@ -597,7 +597,7 @@ Verify the PipelineRun was initialized with a set of expected parameters. By def
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `PipelineRun params, %v, do not match expectation, %v.`
 * Code: `external_parameters.pipeline_run_params`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/external_parameters/external_parameters.rego#L15[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/external_parameters/external_parameters.rego#L15[Source, window="_blank"]
 
 [#external_parameters__pipeline_run_params_provided]
 === link:#external_parameters__pipeline_run_params_provided[PipelineRun params provided]
@@ -609,7 +609,7 @@ Confirm the `pipeline_run_params` rule data was provided.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `external_parameters.pipeline_run_params_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/external_parameters/external_parameters.rego#L39[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/external_parameters/external_parameters.rego#L39[Source, window="_blank"]
 
 [#external_parameters__restrict_shared_volumes]
 === link:#external_parameters__restrict_shared_volumes[Restrict shared volumes]
@@ -619,7 +619,7 @@ Verify the PipelineRun did not use any pre-existing PersistentVolumeClaim worksp
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `PipelineRun uses shared volumes, %v.`
 * Code: `external_parameters.restrict_shared_volumes`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/external_parameters/external_parameters.rego#L54[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/external_parameters/external_parameters.rego#L54[Source, window="_blank"]
 
 [#github_certificate_package]
 == link:#github_certificate_package[GitHub Certificate Checks]
@@ -636,7 +636,7 @@ Check if the image signature certificate contains the expected GitHub extensions
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Missing extension %q`
 * Code: `github_certificate.gh_workflow_extensions`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L15[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L15[Source, window="_blank"]
 
 [#github_certificate__gh_workflow_name]
 === link:#github_certificate__gh_workflow_name[GitHub Workflow Name]
@@ -646,7 +646,7 @@ Check if the value of the GitHub Workflow Name extension in the image signature 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Name %q not in allowed list: %v`
 * Code: `github_certificate.gh_workflow_name`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L63[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L63[Source, window="_blank"]
 
 [#github_certificate__gh_workflow_repository]
 === link:#github_certificate__gh_workflow_repository[GitHub Workflow Repository]
@@ -656,7 +656,7 @@ Check if the value of the GitHub Workflow Repository extension in the image sign
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Repository %q not in allowed list: %v`
 * Code: `github_certificate.gh_workflow_repository`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L33[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L33[Source, window="_blank"]
 
 [#github_certificate__gh_workflow_ref]
 === link:#github_certificate__gh_workflow_ref[GitHub Workflow Repository]
@@ -666,7 +666,7 @@ Check if the value of the GitHub Workflow Ref extension in the image signature c
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Ref %q not in allowed list: %v`
 * Code: `github_certificate.gh_workflow_ref`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L48[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L48[Source, window="_blank"]
 
 [#github_certificate__gh_workflow_trigger]
 === link:#github_certificate__gh_workflow_trigger[GitHub Workflow Trigger]
@@ -676,7 +676,7 @@ Check if the value of the GitHub Workflow Trigger extension in the image signatu
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Trigger %q not in allowed list: %v`
 * Code: `github_certificate.gh_workflow_trigger`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L78[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L78[Source, window="_blank"]
 
 [#github_certificate__rule_data_provided]
 === link:#github_certificate__rule_data_provided[Rule data provided]
@@ -688,7 +688,7 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `github_certificate.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L93[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/github_certificate/github_certificate.rego#L93[Source, window="_blank"]
 
 [#hermetic_build_task_package]
 == link:#hermetic_build_task_package[Hermetic build task]
@@ -707,7 +707,7 @@ Verify the build task in the PipelineRun attestation was invoked with the proper
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Build task was not invoked with the hermetic parameter set`
 * Code: `hermetic_build_task.build_task_hermetic`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/hermetic_build_task/hermetic_build_task.rego#L15[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/hermetic_build_task/hermetic_build_task.rego#L15[Source, window="_blank"]
 
 [#labels_package]
 == link:#labels_package[Labels]
@@ -726,7 +726,7 @@ Check the image for the presence of labels that have been deprecated. Use the ru
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The %q label is deprecated, replace with %q`
 * Code: `labels.deprecated_labels`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L87[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L87[Source, window="_blank"]
 
 [#labels__disallowed_inherited_labels]
 === link:#labels__disallowed_inherited_labels[Disallowed inherited labels]
@@ -738,7 +738,7 @@ Check that certain labels on the image have different values than the labels fro
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The %q label should not be inherited from the parent image`
 * Code: `labels.disallowed_inherited_labels`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L136[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L136[Source, window="_blank"]
 
 [#labels__inaccessible_config]
 === link:#labels__inaccessible_config[Inaccessible image config]
@@ -750,7 +750,7 @@ The image config is not accessible.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Image config of the image %q is inaccessible`
 * Code: `labels.inaccessible_config`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L65[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L65[Source, window="_blank"]
 
 [#labels__inaccessible_manifest]
 === link:#labels__inaccessible_manifest[Inaccessible image manifest]
@@ -762,7 +762,7 @@ The image manifest is not accessible.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Manifest of the image %q is inaccessible`
 * Code: `labels.inaccessible_manifest`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L46[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L46[Source, window="_blank"]
 
 [#labels__inaccessible_parent_config]
 === link:#labels__inaccessible_parent_config[Inaccessible parent image config]
@@ -774,7 +774,7 @@ The parent image config is not accessible.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Image config of the image %q, parent of image %q is inaccessible`
 * Code: `labels.inaccessible_parent_config`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L199[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L199[Source, window="_blank"]
 
 [#labels__inaccessible_parent_manifest]
 === link:#labels__inaccessible_parent_manifest[Inaccessible parent image manifest]
@@ -786,7 +786,7 @@ The parent image manifest is not accessible.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Manifest of the image %q, parent of image %q is inaccessible`
 * Code: `labels.inaccessible_parent_manifest`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L181[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L181[Source, window="_blank"]
 
 [#labels__optional_labels]
 === link:#labels__optional_labels[Optional labels]
@@ -798,7 +798,7 @@ Check the image for the presence of labels that are recommended, but not require
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `The optional %q label is missing. Label description: %s`
 * Code: `labels.optional_labels`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L19[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L19[Source, window="_blank"]
 
 [#labels__required_labels]
 === link:#labels__required_labels[Required labels]
@@ -810,7 +810,7 @@ Check the image for the presence of labels that are required. Use the rule data 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `labels.required_labels`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L115[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L115[Source, window="_blank"]
 
 [#labels__rule_data_provided]
 === link:#labels__rule_data_provided[Rule data provided]
@@ -822,7 +822,7 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `labels.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L162[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/labels/labels.rego#L162[Source, window="_blank"]
 
 [#olm_package]
 == link:#olm_package[OLM]
@@ -841,7 +841,7 @@ Check the `spec.version` value in the ClusterServiceVersion manifest of the OLM 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The ClusterServiceVersion spec.version, %q, is not a valid semver`
 * Code: `olm.csv_semver_format`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L17[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L17[Source, window="_blank"]
 
 [#olm__feature_annotations_format]
 === link:#olm__feature_annotations_format[Feature annotations have expected value]
@@ -853,7 +853,7 @@ Check the feature annotations in the ClusterServiceVersion manifest of the OLM b
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The annotation %q is either missing or has an unexpected value`
 * Code: `olm.feature_annotations_format`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L64[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L64[Source, window="_blank"]
 
 [#olm__allowed_registries]
 === link:#olm__allowed_registries[Images referenced by OLM bundle are from allowed registries]
@@ -866,7 +866,7 @@ Each image referenced by the OLM bundle should match an entry in the list of pre
 * FAILURE message: `The %q CSV image reference is not from an allowed registry.`
 * Code: `olm.allowed_registries`
 * Effective from: `2024-09-01T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L287[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L287[Source, window="_blank"]
 
 [#olm__olm_bundle_multi_arch]
 === link:#olm__olm_bundle_multi_arch[OLM bundle images are not multi-arch]
@@ -879,7 +879,7 @@ OLM bundle images should be built for a single architecture. They should not be 
 * FAILURE message: `The %q bundle image is a multi-arch reference.`
 * Code: `olm.olm_bundle_multi_arch`
 * Effective from: `2025-5-01T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L320[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L320[Source, window="_blank"]
 
 [#olm__allowed_registries_related]
 === link:#olm__allowed_registries_related[Related images references are from allowed registries]
@@ -892,7 +892,7 @@ Each image indicated as a related image should match an entry in the list of pre
 * FAILURE message: `The %q related image reference is not from an allowed registry.`
 * Code: `olm.allowed_registries_related`
 * Effective from: `2025-04-15T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L217[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L217[Source, window="_blank"]
 
 [#olm__required_olm_features_annotations_provided]
 === link:#olm__required_olm_features_annotations_provided[Required OLM feature annotations list provided]
@@ -902,7 +902,7 @@ Confirm the `required_olm_features_annotations` rule data was provided, since it
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `olm.required_olm_features_annotations_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L109[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L109[Source, window="_blank"]
 
 [#olm__subscriptions_annotation_format]
 === link:#olm__subscriptions_annotation_format[Subscription annotation has expected value]
@@ -915,7 +915,7 @@ Check the value of the operators.openshift.io/valid-subscription annotation from
 * FAILURE message: `%s`
 * Code: `olm.subscriptions_annotation_format`
 * Effective from: `2024-04-18T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L88[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L88[Source, window="_blank"]
 
 [#olm__inaccessible_snapshot_references]
 === link:#olm__inaccessible_snapshot_references[Unable to access images in the input snapshot]
@@ -928,7 +928,7 @@ Check the input snapshot and make sure all the images are accessible.
 * FAILURE message: `The %q image reference is not accessible in the input snapshot.`
 * Code: `olm.inaccessible_snapshot_references`
 * Effective from: `2024-08-15T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L156[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L156[Source, window="_blank"]
 
 [#olm__inaccessible_related_images]
 === link:#olm__inaccessible_related_images[Unable to access related images for a component]
@@ -941,7 +941,7 @@ Check the input image for the presence of related images. Ensure that all images
 * FAILURE message: `The %q related image reference is not accessible.`
 * Code: `olm.inaccessible_related_images`
 * Effective from: `2025-03-10T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L178[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L178[Source, window="_blank"]
 
 [#olm__unmapped_references]
 === link:#olm__unmapped_references[Unmapped images in OLM bundle]
@@ -954,7 +954,7 @@ Check the OLM bundle image for the presence of unmapped image references. Unmapp
 * FAILURE message: `The %q CSV image reference is not in the snapshot or accessible.`
 * Code: `olm.unmapped_references`
 * Effective from: `2024-08-15T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L247[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L247[Source, window="_blank"]
 
 [#olm__unpinned_references]
 === link:#olm__unpinned_references[Unpinned images in OLM bundle]
@@ -966,7 +966,7 @@ Check the OLM bundle image for the presence of unpinned image references. Unpinn
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The %q image reference is not pinned at %s.`
 * Code: `olm.unpinned_references`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L38[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L38[Source, window="_blank"]
 
 [#olm__unpinned_snapshot_references]
 === link:#olm__unpinned_snapshot_references[Unpinned images in input snapshot]
@@ -979,7 +979,7 @@ Check the input snapshot for the presence of unpinned image references. Unpinned
 * FAILURE message: `The %q image reference is not pinned in the input snapshot.`
 * Code: `olm.unpinned_snapshot_references`
 * Effective from: `2024-08-15T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L126[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/olm/olm.rego#L126[Source, window="_blank"]
 
 [#provenance_materials_package]
 == link:#provenance_materials_package[Provenance Materials]
@@ -998,7 +998,7 @@ Confirm that the result of the git-clone task is included in the materials secti
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Entry in materials for the git repo %q and commit %q not found`
 * Code: `provenance_materials.git_clone_source_matches_provenance`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/provenance_materials/provenance_materials.rego#L37[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/provenance_materials/provenance_materials.rego#L37[Source, window="_blank"]
 
 [#provenance_materials__git_clone_task_found]
 === link:#provenance_materials__git_clone_task_found[Git clone task found]
@@ -1010,7 +1010,7 @@ Confirm that the attestation contains a git-clone task with `commit` and `url` t
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Task git-clone not found`
 * Code: `provenance_materials.git_clone_task_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/provenance_materials/provenance_materials.rego#L15[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/provenance_materials/provenance_materials.rego#L15[Source, window="_blank"]
 
 [#quay_expiration_package]
 == link:#quay_expiration_package[Quay expiration]
@@ -1029,7 +1029,7 @@ Check the image metadata for the presence of a "quay.expires-after" label. If it
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The image has a 'quay.expires-after' label set to '%s'`
 * Code: `quay_expiration.expires_label`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/quay_expiration/quay_expiration.rego#L16[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/quay_expiration/quay_expiration.rego#L16[Source, window="_blank"]
 
 [#rhtap_multi_ci_package]
 == link:#rhtap_multi_ci_package[RHTAP Multi-CI]
@@ -1048,7 +1048,7 @@ Confirm the attestation created by the RHTAP Multi-CI build pipeline matches the
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `RHTAP %s attestation problem: %s`
 * Code: `rhtap_multi_ci.attestation_format`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rhtap_multi_ci/rhtap_multi_ci.rego#L40[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rhtap_multi_ci/rhtap_multi_ci.rego#L40[Source, window="_blank"]
 
 [#rhtap_multi_ci__attestation_found]
 === link:#rhtap_multi_ci__attestation_found[SLSA Provenance Attestation Found]
@@ -1060,7 +1060,7 @@ Verify an attestation created by the RHTAP Multi-CI build pipeline is present.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `A SLSA v1.0 provenance with one of the following RHTAP Multi-CI build types was not found: %s.`
 * Code: `rhtap_multi_ci.attestation_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rhtap_multi_ci/rhtap_multi_ci.rego#L16[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rhtap_multi_ci/rhtap_multi_ci.rego#L16[Source, window="_blank"]
 
 [#rpm_packages_package]
 == link:#rpm_packages_package[RPM Packages]
@@ -1078,7 +1078,7 @@ Check if there is more than one version of the same RPM installed across differe
 * FAILURE message: `Multiple versions of the %q RPM were found: %s`
 * Code: `rpm_packages.unique_version`
 * Effective from: `2025-06-28T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_packages/rpm_packages.rego#L17[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_packages/rpm_packages.rego#L17[Source, window="_blank"]
 
 [#rpm_pipeline_package]
 == link:#rpm_pipeline_package[RPM Pipeline]
@@ -1095,7 +1095,7 @@ The Tekton Task used specifies an invalid pipeline. The Task is annotated with `
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Task %q uses invalid pipleline %s, which is not in the list of valid pipelines: %s`
 * Code: `rpm_pipeline.invalid_pipeline`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_pipeline/rpm_pipeline.rego#L18[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_pipeline/rpm_pipeline.rego#L18[Source, window="_blank"]
 
 [#rpm_repos_package]
 == link:#rpm_repos_package[RPM Repos]
@@ -1115,7 +1115,7 @@ Each RPM package listed in an SBOM must specify the repository id that it comes 
 * FAILURE message: `RPM repo id check failed: %s`
 * Code: `rpm_repos.ids_known`
 * Effective from: `2024-11-10T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_repos/rpm_repos.rego#L38[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_repos/rpm_repos.rego#L38[Source, window="_blank"]
 
 [#rpm_repos__rule_data_provided]
 === link:#rpm_repos__rule_data_provided[Known repo id list provided]
@@ -1127,7 +1127,7 @@ A list of known and permitted repository ids should be available in the rule dat
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Rule data '%s' has unexpected format: %s`
 * Code: `rpm_repos.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_repos/rpm_repos.rego#L16[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_repos/rpm_repos.rego#L16[Source, window="_blank"]
 
 [#rpm_signature_package]
 == link:#rpm_signature_package[RPM Signature]
@@ -1147,7 +1147,7 @@ The SLSA Provenance attestation for the image is inspected to ensure RPMs have b
 * FAILURE message: `Signing key %q is not one of the allowed keys: %s`
 * Code: `rpm_signature.allowed`
 * Effective from: `2024-10-05T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_signature/rpm_signature.rego#L15[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_signature/rpm_signature.rego#L15[Source, window="_blank"]
 
 [#rpm_signature__result_format]
 === link:#rpm_signature__result_format[Result format]
@@ -1158,7 +1158,7 @@ Confirm the format of the RPMS_DATA result is in the expected format.
 * FAILURE message: `%s`
 * Code: `rpm_signature.result_format`
 * Effective from: `2024-10-05T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_signature/rpm_signature.rego#L38[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_signature/rpm_signature.rego#L38[Source, window="_blank"]
 
 [#rpm_signature__rule_data_provided]
 === link:#rpm_signature__rule_data_provided[Rule data provided]
@@ -1169,7 +1169,7 @@ Confirm the expected `allowed_rpm_signature_keys` rule data key has been provide
 * FAILURE message: `%s`
 * Code: `rpm_signature.rule_data_provided`
 * Effective from: `2024-10-05T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_signature/rpm_signature.rego#L55[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_signature/rpm_signature.rego#L55[Source, window="_blank"]
 
 [#sbom_package]
 == link:#sbom_package[SBOM]
@@ -1188,7 +1188,7 @@ Confirm the `disallowed_packages` and `disallowed_attributes` rule data were pro
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `sbom.disallowed_packages_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom/sbom.rego#L35[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom/sbom.rego#L35[Source, window="_blank"]
 
 [#sbom__found]
 === link:#sbom__found[Found]
@@ -1200,7 +1200,7 @@ Confirm an SBOM attestation exists.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `No SBOM attestations found`
 * Code: `sbom.found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom/sbom.rego#L15[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom/sbom.rego#L15[Source, window="_blank"]
 
 [#sbom_cyclonedx_package]
 == link:#sbom_cyclonedx_package[SBOM CycloneDX]
@@ -1219,7 +1219,7 @@ Confirm the CycloneDX SBOM contains only allowed packages. By default all packag
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Package is not allowed: %s`
 * Code: `sbom_cyclonedx.allowed`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L35[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L35[Source, window="_blank"]
 
 [#sbom_cyclonedx__allowed_package_external_references]
 === link:#sbom_cyclonedx__allowed_package_external_references[Allowed package external references]
@@ -1231,7 +1231,7 @@ Confirm the CycloneDX SBOM contains only packages with explicitly allowed extern
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Package %s has reference %q of type %q which is not explicitly allowed%s`
 * Code: `sbom_cyclonedx.allowed_package_external_references`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L90[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L90[Source, window="_blank"]
 
 [#sbom_cyclonedx__allowed_package_sources]
 === link:#sbom_cyclonedx__allowed_package_sources[Allowed package sources]
@@ -1244,7 +1244,7 @@ For each of the components fetched by Cachi2 which define externalReferences of 
 * FAILURE message: `Package %s fetched by cachi2 was sourced from %q which is not allowed`
 * Code: `sbom_cyclonedx.allowed_package_sources`
 * Effective from: `2024-12-15T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L154[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L154[Source, window="_blank"]
 
 [#sbom_cyclonedx__disallowed_package_attributes]
 === link:#sbom_cyclonedx__disallowed_package_attributes[Disallowed package attributes]
@@ -1257,7 +1257,7 @@ Confirm the CycloneDX SBOM contains only packages without disallowed attributes.
 * FAILURE message: `Package %s has the attribute %q set%s`
 * Code: `sbom_cyclonedx.disallowed_package_attributes`
 * Effective from: `2024-07-31T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L56[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L56[Source, window="_blank"]
 
 [#sbom_cyclonedx__disallowed_package_external_references]
 === link:#sbom_cyclonedx__disallowed_package_external_references[Disallowed package external references]
@@ -1270,7 +1270,7 @@ Confirm the CycloneDX SBOM contains only packages without disallowed external re
 * FAILURE message: `Package %s has reference %q of type %q which is disallowed%s`
 * Code: `sbom_cyclonedx.disallowed_package_external_references`
 * Effective from: `2024-07-31T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L122[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L122[Source, window="_blank"]
 
 [#sbom_cyclonedx__valid]
 === link:#sbom_cyclonedx__valid[Valid]
@@ -1282,7 +1282,7 @@ Check the CycloneDX SBOM has the expected format. It verifies the CycloneDX SBOM
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `CycloneDX SBOM at index %d is not valid: %s`
 * Code: `sbom_cyclonedx.valid`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L14[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L14[Source, window="_blank"]
 
 [#slsa_build_build_service_package]
 == link:#slsa_build_build_service_package[SLSA - Build - Build Service]
@@ -1301,7 +1301,7 @@ Confirm the `allowed_builder_ids` rule data was provided, since it is required b
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `slsa_build_build_service.allowed_builder_ids_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_build_build_service/slsa_build_build_service.rego#L69[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_build_build_service/slsa_build_build_service.rego#L69[Source, window="_blank"]
 
 [#slsa_build_build_service__slsa_builder_id_found]
 === link:#slsa_build_build_service__slsa_builder_id_found[SLSA Builder ID found]
@@ -1313,7 +1313,7 @@ Verify that the attestation attribute predicate.builder.id is set.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Builder ID not set in attestation`
 * Code: `slsa_build_build_service.slsa_builder_id_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_build_build_service/slsa_build_build_service.rego#L20[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_build_build_service/slsa_build_build_service.rego#L20[Source, window="_blank"]
 
 [#slsa_build_build_service__slsa_builder_id_accepted]
 === link:#slsa_build_build_service__slsa_builder_id_accepted[SLSA Builder ID is known and accepted]
@@ -1325,7 +1325,7 @@ Verify that the attestation attribute predicate.builder.id is set to one of the 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Builder ID %q is unexpected`
 * Code: `slsa_build_build_service.slsa_builder_id_accepted`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_build_build_service/slsa_build_build_service.rego#L42[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_build_build_service/slsa_build_build_service.rego#L42[Source, window="_blank"]
 
 [#slsa_build_scripted_build_package]
 == link:#slsa_build_scripted_build_package[SLSA - Build - Scripted Build]
@@ -1346,7 +1346,7 @@ Verify that the predicate.buildConfig.tasks.steps attribute for the task respons
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Build task %q does not contain any steps`
 * Code: `slsa_build_scripted_build.build_script_used`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_build_scripted_build/slsa_build_scripted_build.rego#L21[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_build_scripted_build/slsa_build_scripted_build.rego#L21[Source, window="_blank"]
 
 [#slsa_build_scripted_build__build_task_image_results_found]
 === link:#slsa_build_scripted_build__build_task_image_results_found[Build task set image digest and url task results]
@@ -1358,7 +1358,7 @@ Confirm that a build task exists and it has the expected IMAGE_DIGEST and IMAGE_
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Build task not found`
 * Code: `slsa_build_scripted_build.build_task_image_results_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_build_scripted_build/slsa_build_scripted_build.rego#L48[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_build_scripted_build/slsa_build_scripted_build.rego#L48[Source, window="_blank"]
 
 [#slsa_build_scripted_build__image_built_by_trusted_task]
 === link:#slsa_build_scripted_build__image_built_by_trusted_task[Image built by trusted Task]
@@ -1370,7 +1370,7 @@ Verify the digest of the image being validated is reported by a trusted Task in 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Image %q not built by a trusted task: %s`
 * Code: `slsa_build_scripted_build.image_built_by_trusted_task`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_build_scripted_build/slsa_build_scripted_build.rego#L106[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_build_scripted_build/slsa_build_scripted_build.rego#L106[Source, window="_blank"]
 
 [#slsa_build_scripted_build__subject_build_task_matches]
 === link:#slsa_build_scripted_build__subject_build_task_matches[Provenance subject matches build task image result]
@@ -1382,7 +1382,7 @@ Verify the subject of the attestations matches the IMAGE_DIGEST and IMAGE_URL va
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The attestation subject, %q, does not match any of the images built`
 * Code: `slsa_build_scripted_build.subject_build_task_matches`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_build_scripted_build/slsa_build_scripted_build.rego#L72[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_build_scripted_build/slsa_build_scripted_build.rego#L72[Source, window="_blank"]
 
 [#slsa_provenance_available_package]
 == link:#slsa_provenance_available_package[SLSA - Provenance - Available]
@@ -1401,7 +1401,7 @@ Confirm the `allowed_predicate_types` rule data was provided, since it is requir
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `slsa_provenance_available.allowed_predicate_types_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_provenance_available/slsa_provenance_available.rego#L49[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_provenance_available/slsa_provenance_available.rego#L49[Source, window="_blank"]
 
 [#slsa_provenance_available__attestation_predicate_type_accepted]
 === link:#slsa_provenance_available__attestation_predicate_type_accepted[Expected attestation predicate type found]
@@ -1413,7 +1413,7 @@ Verify that the predicateType field of the attestation indicates the in-toto SLS
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Attestation predicate type %q is not an expected type (%s)`
 * Code: `slsa_provenance_available.attestation_predicate_type_accepted`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_provenance_available/slsa_provenance_available.rego#L20[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_provenance_available/slsa_provenance_available.rego#L20[Source, window="_blank"]
 
 [#slsa_source_version_controlled_package]
 == link:#slsa_source_version_controlled_package[SLSA - Source - Version Controlled]
@@ -1447,7 +1447,7 @@ Ensure each entry in the predicate.materials array with a SHA-1 digest includes 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Material URI %q is not a git URI`
 * Code: `slsa_source_version_controlled.materials_uri_is_git_repo`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_version_controlled/slsa_source_version_controlled.rego#L58[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_source_version_controlled/slsa_source_version_controlled.rego#L58[Source, window="_blank"]
 
 [#slsa_source_version_controlled__materials_format_okay]
 === link:#slsa_source_version_controlled__materials_format_okay[Materials have uri and digest]
@@ -1459,7 +1459,7 @@ Confirm at least one entry in the predicate.materials array of the attestation c
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `No materials match expected format`
 * Code: `slsa_source_version_controlled.materials_format_okay`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_version_controlled/slsa_source_version_controlled.rego#L33[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_source_version_controlled/slsa_source_version_controlled.rego#L33[Source, window="_blank"]
 
 [#slsa_source_version_controlled__materials_include_git_sha]
 === link:#slsa_source_version_controlled__materials_include_git_sha[Materials include git commit shas]
@@ -1471,7 +1471,7 @@ Ensure that each entry in the predicate.materials array with a SHA-1 digest incl
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Material digest %q is not a git commit sha`
 * Code: `slsa_source_version_controlled.materials_include_git_sha`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_version_controlled/slsa_source_version_controlled.rego#L84[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_source_version_controlled/slsa_source_version_controlled.rego#L84[Source, window="_blank"]
 
 [#slsa_source_correlated_package]
 == link:#slsa_source_correlated_package[SLSA - Verification model - Source]
@@ -1492,7 +1492,7 @@ Verify that the provided source code reference is the one being attested.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The expected source code reference %q is not attested`
 * Code: `slsa_source_correlated.expected_source_code_reference`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L67[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L67[Source, window="_blank"]
 
 [#slsa_source_correlated__rule_data_provided]
 === link:#slsa_source_correlated__rule_data_provided[Rule data provided]
@@ -1502,7 +1502,7 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `slsa_source_correlated.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L105[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L105[Source, window="_blank"]
 
 [#slsa_source_correlated__source_code_reference_provided]
 === link:#slsa_source_correlated__source_code_reference_provided[Source code reference provided]
@@ -1514,7 +1514,7 @@ Check if the expected source code reference is provided.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Expected source code reference was not provided for verification`
 * Code: `slsa_source_correlated.source_code_reference_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L20[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L20[Source, window="_blank"]
 
 [#slsa_source_correlated__attested_source_code_reference]
 === link:#slsa_source_correlated__attested_source_code_reference[Source reference]
@@ -1526,7 +1526,7 @@ Attestation contains source reference.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The attested material contains no source code reference`
 * Code: `slsa_source_correlated.attested_source_code_reference`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L41[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/slsa_source_correlated/slsa_source_correlated.rego#L41[Source, window="_blank"]
 
 [#sbom_spdx_package]
 == link:#sbom_spdx_package[SPDX SBOM]
@@ -1545,7 +1545,7 @@ Confirm the SPDX SBOM contains only allowed packages. By default all packages ar
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Package is not allowed: %s`
 * Code: `sbom_spdx.allowed`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L51[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L51[Source, window="_blank"]
 
 [#sbom_spdx__allowed_package_external_references]
 === link:#sbom_spdx__allowed_package_external_references[Allowed package external references]
@@ -1557,7 +1557,7 @@ Confirm the SPDX SBOM contains only packages with explicitly allowed external re
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Package %s has reference %q of type %q which is not explicitly allowed%s`
 * Code: `sbom_spdx.allowed_package_external_references`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L74[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L74[Source, window="_blank"]
 
 [#sbom_spdx__allowed_package_sources]
 === link:#sbom_spdx__allowed_package_sources[Allowed package sources]
@@ -1570,7 +1570,7 @@ For each of the packages fetched by Cachi2 which define externalReferences, veri
 * FAILURE message: `Package %s fetched by cachi2 was sourced from %q which is not allowed`
 * Code: `sbom_spdx.allowed_package_sources`
 * Effective from: `2025-02-17T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L170[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L170[Source, window="_blank"]
 
 [#sbom_spdx__contains_files]
 === link:#sbom_spdx__contains_files[Contains files]
@@ -1582,7 +1582,7 @@ Check the list of files in the SPDX SBOM is not empty.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The list of files is empty`
 * Code: `sbom_spdx.contains_files`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L137[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L137[Source, window="_blank"]
 
 [#sbom_spdx__contains_packages]
 === link:#sbom_spdx__contains_packages[Contains packages]
@@ -1594,7 +1594,7 @@ Check the list of packages in the SPDX SBOM is not empty.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The list of packages is empty`
 * Code: `sbom_spdx.contains_packages`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L36[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L36[Source, window="_blank"]
 
 [#sbom_spdx__disallowed_package_attributes]
 === link:#sbom_spdx__disallowed_package_attributes[Disallowed package attributes]
@@ -1607,7 +1607,7 @@ Confirm the SPDX SBOM contains only packages without disallowed attributes. By d
 * FAILURE message: `Package %s has the attribute %q set%s`
 * Code: `sbom_spdx.disallowed_package_attributes`
 * Effective from: `2025-02-04T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L215[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L215[Source, window="_blank"]
 
 [#sbom_spdx__disallowed_package_external_references]
 === link:#sbom_spdx__disallowed_package_external_references[Disallowed package external references]
@@ -1620,7 +1620,7 @@ Confirm the SPDX SBOM contains only packages without disallowed external referen
 * FAILURE message: `Package %s has reference %q of type %q which is disallowed%s`
 * Code: `sbom_spdx.disallowed_package_external_references`
 * Effective from: `2024-07-31T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L105[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L105[Source, window="_blank"]
 
 [#sbom_spdx__matches_image]
 === link:#sbom_spdx__matches_image[Matches image]
@@ -1632,7 +1632,7 @@ Check the SPDX SBOM targets the image being validated.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Image digest in the SBOM, %q, is not as expected, %q`
 * Code: `sbom_spdx.matches_image`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L152[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L152[Source, window="_blank"]
 
 [#sbom_spdx__valid]
 === link:#sbom_spdx__valid[Valid]
@@ -1644,7 +1644,7 @@ Check the SPDX SBOM has the expected format. It verifies the SPDX SBOM matches t
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `SPDX SBOM at index %d is not valid: %s`
 * Code: `sbom_spdx.valid`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L15[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L15[Source, window="_blank"]
 
 [#schedule_package]
 == link:#schedule_package[Schedule related checks]
@@ -1663,7 +1663,7 @@ Check if the current date is not allowed based on the rule data value from the k
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s is a disallowed date: %s`
 * Code: `schedule.date_restriction`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L38[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L38[Source, window="_blank"]
 
 [#schedule__rule_data_provided]
 === link:#schedule__rule_data_provided[Rule data provided]
@@ -1675,7 +1675,7 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `schedule.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L62[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L62[Source, window="_blank"]
 
 [#schedule__weekday_restriction]
 === link:#schedule__weekday_restriction[Weekday Restriction]
@@ -1687,7 +1687,7 @@ Check if the current weekday is allowed based on the rule data value from the ke
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s is a disallowed weekday: %s`
 * Code: `schedule.weekday_restriction`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L14[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/schedule/schedule.rego#L14[Source, window="_blank"]
 
 [#source_image_package]
 == link:#source_image_package[Source image]
@@ -1705,7 +1705,7 @@ Verify the source container image exists.
 * FAILURE message: `%s`
 * Code: `source_image.exists`
 * Effective from: `2024-06-05T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/source_image/source_image.rego#L15[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/source_image/source_image.rego#L15[Source, window="_blank"]
 
 [#source_image__signed]
 === link:#source_image__signed[Signed]
@@ -1716,7 +1716,7 @@ Verify the source container image is signed.
 * FAILURE message: `%s`
 * Code: `source_image.signed`
 * Effective from: `2024-05-04T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/source_image/source_image.rego#L30[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/source_image/source_image.rego#L30[Source, window="_blank"]
 
 [#attestation_task_bundle_package]
 == link:#attestation_task_bundle_package[Task bundle checks]
@@ -1735,7 +1735,7 @@ Confirm the `trusted_tasks` rule data was provided, since it's required by the p
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Missing required trusted_tasks data`
 * Code: `attestation_task_bundle.trusted_bundles_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L114[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L114[Source, window="_blank"]
 
 [#attestation_task_bundle__task_ref_bundles_not_empty]
 === link:#attestation_task_bundle__task_ref_bundles_not_empty[Task bundle references not empty]
@@ -1747,7 +1747,7 @@ Check that a valid task bundle reference is being used.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Pipeline task '%s' uses an empty bundle image reference`
 * Code: `attestation_task_bundle.task_ref_bundles_not_empty`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L76[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L76[Source, window="_blank"]
 
 [#attestation_task_bundle__task_ref_bundles_pinned]
 === link:#attestation_task_bundle__task_ref_bundles_pinned[Task bundle references pinned to digest]
@@ -1759,7 +1759,7 @@ Check if the Tekton Bundle used for the Tasks in the Pipeline definition is pinn
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Pipeline task '%s' uses an unpinned task bundle reference '%s'`
 * Code: `attestation_task_bundle.task_ref_bundles_pinned`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L20[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L20[Source, window="_blank"]
 
 [#attestation_task_bundle__task_ref_bundles_trusted]
 === link:#attestation_task_bundle__task_ref_bundles_trusted[Task bundles are in trusted tasks list]
@@ -1771,7 +1771,7 @@ For each Task in the SLSA Provenance attestation, check if the Tekton Bundle use
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Pipeline task '%s' uses an untrusted task bundle '%s'`
 * Code: `attestation_task_bundle.task_ref_bundles_trusted`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L93[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L93[Source, window="_blank"]
 
 [#attestation_task_bundle__task_ref_bundles_current]
 === link:#attestation_task_bundle__task_ref_bundles_current[Task bundles are latest versions]
@@ -1783,7 +1783,7 @@ For each Task in the SLSA Provenance attestation, check if the Tekton Bundle use
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Pipeline task '%s' uses an out of date task bundle '%s', new version of the Task must be used before %s`
 * Code: `attestation_task_bundle.task_ref_bundles_current`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L38[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L38[Source, window="_blank"]
 
 [#attestation_task_bundle__tasks_defined_in_bundle]
 === link:#attestation_task_bundle__tasks_defined_in_bundle[Tasks defined using bundle references]
@@ -1793,7 +1793,7 @@ Check for the existence of a task bundle. This rule will fail if the task is not
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Pipeline task '%s' does not contain a bundle reference`
 * Code: `attestation_task_bundle.tasks_defined_in_bundle`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L60[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/attestation_task_bundle/attestation_task_bundle.rego#L60[Source, window="_blank"]
 
 [#tasks_package]
 == link:#tasks_package[Tasks]
@@ -1812,7 +1812,7 @@ Ensure that the all required tasks are resolved from trusted tasks.
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `%s is required and present but not from a trusted task`
 * Code: `tasks.required_untrusted_task_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L34[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L34[Source, window="_blank"]
 
 [#tasks__required_tasks_found]
 === link:#tasks__required_tasks_found[All required tasks were included in the pipeline]
@@ -1824,7 +1824,7 @@ Ensure that the set of required tasks are included in the PipelineRun attestatio
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s is missing`
 * Code: `tasks.required_tasks_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L171[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L171[Source, window="_blank"]
 
 [#tasks__data_provided]
 === link:#tasks__data_provided[Data provided]
@@ -1836,7 +1836,7 @@ Confirm the expected data keys have been provided in the expected format. The ke
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `tasks.data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L285[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L285[Source, window="_blank"]
 
 [#tasks__future_required_tasks_found]
 === link:#tasks__future_required_tasks_found[Future required tasks were found]
@@ -1848,7 +1848,7 @@ Produce a warning when a task that will be required in the future was not includ
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `%s is missing and will be required on %s`
 * Code: `tasks.future_required_tasks_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L86[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L86[Source, window="_blank"]
 
 [#tasks__pinned_task_refs]
 === link:#tasks__pinned_task_refs[Pinned Task references]
@@ -1860,7 +1860,7 @@ Ensure that all Tasks in the SLSA Provenance attestation use an immuntable refer
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Task %s is used by pipeline task %s via an unpinned reference.`
 * Code: `tasks.pinned_task_refs`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L219[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L219[Source, window="_blank"]
 
 [#tasks__pipeline_has_tasks]
 === link:#tasks__pipeline_has_tasks[Pipeline run includes at least one task]
@@ -1872,7 +1872,7 @@ Ensure that at least one Task is present in the PipelineRun attestation.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `No tasks found in PipelineRun attestation`
 * Code: `tasks.pipeline_has_tasks`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L116[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L116[Source, window="_blank"]
 
 [#tasks__pipeline_required_tasks_list_provided]
 === link:#tasks__pipeline_required_tasks_list_provided[Required tasks list for pipeline was provided]
@@ -1884,7 +1884,7 @@ Produce a warning if the required tasks list rule data was not provided.
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `Required tasks do not exist for pipeline`
 * Code: `tasks.pipeline_required_tasks_list_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L65[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L65[Source, window="_blank"]
 
 [#tasks__required_tasks_list_provided]
 === link:#tasks__required_tasks_list_provided[Required tasks list was provided]
@@ -1896,7 +1896,7 @@ Confirm the `required-tasks` rule data was provided, since it's required by the 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Missing required required-tasks data`
 * Code: `tasks.required_tasks_list_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L195[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L195[Source, window="_blank"]
 
 [#tasks__successful_pipeline_tasks]
 === link:#tasks__successful_pipeline_tasks[Successful pipeline tasks]
@@ -1908,7 +1908,7 @@ Ensure that all of the Tasks in the Pipeline completed successfully. Note that s
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Pipeline task %q did not complete successfully, %q`
 * Code: `tasks.successful_pipeline_tasks`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L141[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L141[Source, window="_blank"]
 
 [#tasks__unsupported]
 === link:#tasks__unsupported[Task version unsupported]
@@ -1918,7 +1918,7 @@ The Tekton Task used is or will be unsupported. The Task is annotated with `buil
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Task %q is used by pipeline task %q is or will be unsupported as of %s. %s`
 * Code: `tasks.unsupported`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L246[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L246[Source, window="_blank"]
 
 [#test_package]
 == link:#test_package[Test]
@@ -1938,7 +1938,7 @@ Ensure that task producing the IMAGES_PROCESSED result contains the digests of t
 * FAILURE message: `Test '%s' did not process image with digest '%s'.`
 * Code: `test.test_all_images`
 * Effective from: `2024-05-29T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test/test.rego#L239[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test/test.rego#L239[Source, window="_blank"]
 
 [#test__no_failed_informative_tests]
 === link:#test__no_failed_informative_tests[No informative tests failed]
@@ -1950,7 +1950,7 @@ Produce a warning if any informative tests have their result set to "FAILED". Th
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `The Task %q from the build Pipeline reports a failed informative test`
 * Code: `test.no_failed_informative_tests`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test/test.rego#L17[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test/test.rego#L17[Source, window="_blank"]
 
 [#test__no_erred_tests]
 === link:#test__no_erred_tests[No tests erred]
@@ -1962,7 +1962,7 @@ Produce a violation if any tests have their result set to "ERROR". The result ty
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The Task %q from the build Pipeline reports a test erred`
 * Code: `test.no_erred_tests`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test/test.rego#L169[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test/test.rego#L169[Source, window="_blank"]
 
 [#test__no_failed_tests]
 === link:#test__no_failed_tests[No tests failed]
@@ -1974,7 +1974,7 @@ Produce a violation if any non-informative tests have their result set to "FAILE
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The Task %q from the build Pipeline reports a failed test`
 * Code: `test.no_failed_tests`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test/test.rego#L144[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test/test.rego#L144[Source, window="_blank"]
 
 [#test__no_test_warnings]
 === link:#test__no_test_warnings[No tests produced warnings]
@@ -1986,7 +1986,7 @@ Produce a warning if any tests have their result set to "WARNING". The result ty
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `The Task %q from the build Pipeline reports a test contains warnings`
 * Code: `test.no_test_warnings`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test/test.rego#L41[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test/test.rego#L41[Source, window="_blank"]
 
 [#test__no_skipped_tests]
 === link:#test__no_skipped_tests[No tests were skipped]
@@ -1999,7 +1999,7 @@ Produce a violation if any tests have their result set to "SKIPPED". A skipped r
 * FAILURE message: `The Task %q from the build Pipeline reports a test was skipped`
 * Code: `test.no_skipped_tests`
 * Effective from: `2023-12-08T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test/test.rego#L192[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test/test.rego#L192[Source, window="_blank"]
 
 [#test__test_results_known]
 === link:#test__test_results_known[No unsupported test result values found]
@@ -2011,7 +2011,7 @@ Ensure all test data result values are in the set of known/supported result valu
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The Task %q from the build Pipeline has an unsupported test result %q`
 * Code: `test.test_results_known`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test/test.rego#L111[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test/test.rego#L111[Source, window="_blank"]
 
 [#test__rule_data_provided]
 === link:#test__rule_data_provided[Rule data provided]
@@ -2023,7 +2023,7 @@ Confirm the expected rule data keys have been provided in the expected format. T
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `test.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test/test.rego#L219[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test/test.rego#L219[Source, window="_blank"]
 
 [#test__test_data_found]
 === link:#test__test_data_found[Test data found in task results]
@@ -2035,7 +2035,7 @@ Ensure that at least one of the tasks in the pipeline includes a TEST_OUTPUT tas
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `No test data found`
 * Code: `test.test_data_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test/test.rego#L64[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test/test.rego#L64[Source, window="_blank"]
 
 [#test__test_results_found]
 === link:#test__test_results_found[Test data includes results key]
@@ -2047,12 +2047,12 @@ Each test result is expected to have a `results` key. Verify that the `results` 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Found tests without results`
 * Code: `test.test_results_found`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/test/test.rego#L88[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/test/test.rego#L88[Source, window="_blank"]
 
 [#trusted_task_package]
 == link:#trusted_task_package[Trusted Task checks]
 
-This package is used to verify all the Tekton Tasks involved in building the image are trusted. Trust is established by comparing the Task references found in the SLSA Provenance with a pre-defined list of trusted Tasks, which is expected to be provided as a data source that creates the `data.trusted_tasks` in the format demonstrated at https://github.com/enterprise-contract/ec-policies/blob/main/example/data/trusted_tekton_tasks.yml. The list can be extended or customized using the `trusted_tasks` rule data key which is merged into the `trusted_tasks` data.
+This package is used to verify all the Tekton Tasks involved in building the image are trusted. Trust is established by comparing the Task references found in the SLSA Provenance with a pre-defined list of trusted Tasks, which is expected to be provided as a data source that creates the `data.trusted_tasks` in the format demonstrated at https://github.com/conforma/policy/blob/main/example/data/trusted_tekton_tasks.yml. The list can be extended or customized using the `trusted_tasks` rule data key which is merged into the `trusted_tasks` data.
 
 * Package name: `trusted_task`
 
@@ -2066,7 +2066,7 @@ Confirm the expected `trusted_tasks` data keys have been provided in the expecte
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `trusted_task.data_format`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L219[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L219[Source, window="_blank"]
 
 [#trusted_task__pinned]
 === link:#trusted_task__pinned[Task references are pinned]
@@ -2079,7 +2079,7 @@ Check if all Tekton Tasks use a Task definition by a pinned reference. When usin
 * WARNING message: `Pipeline task %q uses an unpinned task reference, %s`
 * Code: `trusted_task.pinned`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L49[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L49[Source, window="_blank"]
 
 [#trusted_task__tagged]
 === link:#trusted_task__tagged[Task references are tagged]
@@ -2092,7 +2092,7 @@ Check if all Tekton Tasks defined with the bundle format contain a tag reference
 * WARNING message: `Pipeline task %q uses an untagged task reference, %s`
 * Code: `trusted_task.tagged`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L25[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L25[Source, window="_blank"]
 
 [#trusted_task__data]
 === link:#trusted_task__data[Task tracking data was provided]
@@ -2105,7 +2105,7 @@ Confirm the `trusted_tasks` rule data was provided, since it's required by the p
 * FAILURE message: `Missing required trusted_tasks data`
 * Code: `trusted_task.data`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L168[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L168[Source, window="_blank"]
 
 [#trusted_task__trusted]
 === link:#trusted_task__trusted[Tasks are trusted]
@@ -2118,7 +2118,7 @@ Check the trust of the Tekton Tasks used in the build Pipeline. There are two mo
 * FAILURE message: `%s`
 * Code: `trusted_task.trusted`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L104[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L104[Source, window="_blank"]
 
 [#trusted_task__current]
 === link:#trusted_task__current[Tasks using the latest versions]
@@ -2131,7 +2131,7 @@ Check if all Tekton Tasks use the latest known Task reference. When warnings wil
 * WARNING message: `A newer version of task %q exists. Please update before %s. The current bundle is %q and the latest bundle ref is %q`
 * Code: `trusted_task.current`
 * Effective from: `2024-05-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L75[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L75[Source, window="_blank"]
 
 [#trusted_task__valid_trusted_artifact_inputs]
 === link:#trusted_task__valid_trusted_artifact_inputs[Trusted Artifact produced in pipeline]
@@ -2143,7 +2143,7 @@ All input trusted artifacts must be produced on the pipeline. If they are not th
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Code tampering detected, input %q for task %q was not produced by the pipeline as attested.`
 * Code: `trusted_task.valid_trusted_artifact_inputs`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L130[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L130[Source, window="_blank"]
 
 [#trusted_task__trusted_parameters]
 === link:#trusted_task__trusted_parameters[Trusted parameters]
@@ -2156,7 +2156,7 @@ Confirm certain parameters provided to each builder Task have come from trusted 
 * FAILURE message: `The %q parameter of the %q PipelineTask includes an untrusted digest: %s`
 * Code: `trusted_task.trusted_parameters`
 * Effective from: `2021-07-04T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L188[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/trusted_task/trusted_task.rego#L188[Source, window="_blank"]
 
 [#rpm_ostree_task_package]
 == link:#rpm_ostree_task_package[rpm-ostree Task]
@@ -2176,7 +2176,7 @@ Verify the BUILDER_IMAGE parameter of the rpm-ostree Task uses an image referenc
 * FAILURE message: `%s`
 * Code: `rpm_ostree_task.builder_image_param`
 * Effective from: `2024-03-20T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_ostree_task/rpm_ostree_task.rego#L16[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_ostree_task/rpm_ostree_task.rego#L16[Source, window="_blank"]
 
 [#rpm_ostree_task__rule_data]
 === link:#rpm_ostree_task__rule_data[Rule data]
@@ -2188,4 +2188,4 @@ Verify the rule data used by this package, `allowed_rpm_ostree_builder_image_pre
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `rpm_ostree_task.rule_data`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/release/rpm_ostree_task/rpm_ostree_task.rego#L37[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_ostree_task/rpm_ostree_task.rego#L37[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/stepaction_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/stepaction_policy.adoc
@@ -21,7 +21,7 @@ Confirm the StepAction uses a container image with a URL that matches one of the
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Image ref %q is disallowed`
 * Code: `image.permitted`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/stepaction/image/image.rego#L38[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/stepaction/image/image.rego#L38[Source, window="_blank"]
 
 [#image__accessible]
 === link:#image__accessible[Image is accessible]
@@ -33,7 +33,7 @@ Confirm the container image used in the StepTemplate is accessible.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Image ref %q is inaccessible`
 * Code: `image.accessible`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/stepaction/image/image.rego#L16[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/stepaction/image/image.rego#L16[Source, window="_blank"]
 
 [#image__rule_data]
 === link:#image__rule_data[Rule data provided]
@@ -45,7 +45,7 @@ Confirm the `allowed_step_image_registry_prefixes` rule data is provided.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `image.rule_data`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/stepaction/image/image.rego#L62[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/stepaction/image/image.rego#L62[Source, window="_blank"]
 
 [#kind_package]
 == link:#kind_package[Tekton StepAction kind checks]
@@ -62,4 +62,4 @@ Confirm the StepAction definition has the kind "StepAction".
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Unexpected kind %q for StepAction definition`
 * Code: `kind.valid`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/stepaction/kind/kind.rego#L14[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/stepaction/kind/kind.rego#L14[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/task_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/task_policy.adoc
@@ -22,7 +22,7 @@ Confirm that each step in the Task uses a container image that is accessible.
 * FAILURE message: `Step %d uses inaccessible image ref '%s'`
 * Code: `step_images.step_images_accessible`
 * Effective from: `2025-02-10T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/step_images/step_images.rego#L14[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/task/step_images/step_images.rego#L14[Source, window="_blank"]
 
 [#step_image_registries_package]
 == link:#step_image_registries_package[Tekton Task Step image registry policies]
@@ -41,7 +41,7 @@ Confirm the `allowed_step_image_registry_prefixes` rule data was provided, since
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `step_image_registries.step_image_registry_prefix_list_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/step_image_registries/step_image_registries.rego#L43[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/task/step_image_registries/step_image_registries.rego#L43[Source, window="_blank"]
 
 [#step_image_registries__step_images_permitted]
 === link:#step_image_registries__step_images_permitted[Step images come from permitted registry]
@@ -53,7 +53,7 @@ Confirm that each step in the Task uses a container image with a URL that matche
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Step %d uses disallowed image ref '%s'`
 * Code: `step_image_registries.step_images_permitted`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/step_image_registries/step_image_registries.rego#L16[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/task/step_image_registries/step_image_registries.rego#L16[Source, window="_blank"]
 
 [#annotations_package]
 == link:#annotations_package[Tekton Task annotations]
@@ -70,7 +70,7 @@ Make sure to use the date format in RFC3339 format in the "build.appstudio.redha
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Expires on time is not in RFC3339 format: %q`
 * Code: `annotations.expires_on_format`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/annotations/annotations.rego#L14[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/task/annotations/annotations.rego#L14[Source, window="_blank"]
 
 [#results_package]
 == link:#results_package[Tekton Task result]
@@ -87,7 +87,7 @@ Verify if Task defines the required result. This is controlled by the `required_
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `results.required`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/results/results.rego#L13[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/task/results/results.rego#L13[Source, window="_blank"]
 
 [#results__rule_data_provided]
 === link:#results__rule_data_provided[Rule data provided]
@@ -99,7 +99,7 @@ Confirm the expected `required_task_results` rule data key has been provided in 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s`
 * Code: `results.rule_data_provided`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/results/results.rego#L27[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/task/results/results.rego#L27[Source, window="_blank"]
 
 [#kind_package]
 == link:#kind_package[Tekton task kind checks]
@@ -116,7 +116,7 @@ Confirm the task definition includes the kind field.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Required field 'kind' not found`
 * Code: `kind.kind_present`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/kind/kind.rego#L29[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/task/kind/kind.rego#L29[Source, window="_blank"]
 
 [#kind__expected_kind]
 === link:#kind__expected_kind[Task definition has expected kind]
@@ -126,7 +126,7 @@ Confirm the task definition has the kind "Task".
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Unexpected kind '%s' for task definition`
 * Code: `kind.expected_kind`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/kind/kind.rego#L16[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/task/kind/kind.rego#L16[Source, window="_blank"]
 
 [#trusted_artifacts_package]
 == link:#trusted_artifacts_package[Trusted Artifacts Conventions]
@@ -143,7 +143,7 @@ Trusted Artifact parameters follow the expected naming convention.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The parameter %q of the Task %q does not use the _ARTIFACT suffix`
 * Code: `trusted_artifacts.parameter`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/trusted_artifacts/trusted_artifacts.rego#L15[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/task/trusted_artifacts/trusted_artifacts.rego#L15[Source, window="_blank"]
 
 [#trusted_artifacts__result]
 === link:#trusted_artifacts__result[Result]
@@ -153,7 +153,7 @@ Trusted Artifact results follow the expected naming convention.
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `The result %q of the Task %q does not use the _ARTIFACT suffix`
 * Code: `trusted_artifacts.result`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/trusted_artifacts/trusted_artifacts.rego#L28[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/task/trusted_artifacts/trusted_artifacts.rego#L28[Source, window="_blank"]
 
 [#trusted_artifacts__workspace]
 === link:#trusted_artifacts__workspace[Workspace]
@@ -164,4 +164,4 @@ Tasks that implement the Trusted Artifacts pattern should not allow general purp
 * FAILURE message: `General purpose workspace %q is not allowed`
 * Code: `trusted_artifacts.workspace`
 * Effective from: `2024-07-07T00:00:00Z`
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/policy/task/trusted_artifacts/trusted_artifacts.rego#L41[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/task/trusted_artifacts/trusted_artifacts.rego#L41[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/trusting_tasks.adoc
+++ b/antora/docs/modules/ROOT/pages/trusting_tasks.adoc
@@ -4,7 +4,7 @@
 :attestation-task-bundle: release_policy#attestation_task_bundle_package
 :image-built-by-trusted-task: release_policy#slsa_build_scripted_build__image_built_by_trusted_task
 :build-definitions: https://github.com/konflux-ci/build-definitions
-:ec-policies: https://github.com/enterprise-contract/ec-policies
+:policy: https://github.com/conforma/policy
 :ec-track-bundle: https://conforma.dev/docs/ec-cli/ec_track_bundle.html
 :tekton-bundles: https://tekton.dev/docs/pipelines/pipelines/#tekton-bundles
 
@@ -169,8 +169,8 @@ publicKey: "k8s://openshift-pipelines/public-key"
 sources:
   - name: Default with extra source
     policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/release
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/release
 
     data:
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest

--- a/docs/asciidoc/policy.template
+++ b/docs/asciidoc/policy.template
@@ -54,7 +54,7 @@ Rules included:{{ "\n" }}
 * Effective from: `{{ . }}`
 {{- end }}{{/* index .Custom "effective_on" */}}
 {{- if not (isBuiltIn .) }}
-* https://github.com/enterprise-contract/ec-policies/blob/{page-origin-refhash}/{{ .Location.File }}#L{{ .Location.Row }}[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/{{ .Location.File }}#L{{ .Location.Row }}[Source, window="_blank"]
 {{- end }}{{/* isBuiltIn */}}
 {{- end }}{{/* range .Rules */}}
 

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,6 +1,6 @@
-module github.com/enterprise-contract/ec-policies/docs
+module github.com/conforma/policy/docs
 
-go 1.23.6
+go 1.24.2
 
 require github.com/open-policy-agent/opa v0.68.0
 

--- a/docs/main.go
+++ b/docs/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/enterprise-contract/ec-policies/docs/asciidoc"
+	"github.com/conforma/policy/docs/asciidoc"
 )
 
 var adoc = flag.String("adoc", "", "Location of the generated Asciidoc files")

--- a/example/data/required_tasks.yml
+++ b/example/data/required_tasks.yml
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Usage: https://conforma.dev/docs/ec-policies/release_policy.html#tasks_package
+# Usage: https://conforma.dev/docs/policy/release_policy.html#tasks_package
 pipeline-required-tasks:
   fbc:
     - effective_on: "2023-08-31T00:00:00Z"
@@ -85,7 +85,7 @@ pipeline-required-tasks:
         - show-sbom
         - summary
 
-# Usage: https://conforma.dev/docs/ec-policies/release_policy.html#tasks_package
+# Usage: https://conforma.dev/docs/policy/release_policy.html#tasks_package
 required-tasks:
   - effective_on: "2023-08-31T00:00:00Z"
     tasks:

--- a/example/data/rule_data.yml
+++ b/example/data/rule_data.yml
@@ -16,7 +16,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 rule_data:
-  # Usage: https://conforma.dev/docs/ec-policies/release_policy.html#base_image_registries__allowed_registries_provided
+  # Usage: https://conforma.dev/docs/policy/release_policy.html#base_image_registries__allowed_registries_provided
   allowed_registry_prefixes:
   - localhost:5000/
   - registry.local/namespace/repo/
@@ -24,7 +24,7 @@ rule_data:
   - docker.io/
   - registry.access.redhat.com
 
-  # Usage: https://conforma.dev/docs/ec-policies/release_policy.html#step_image_registries_package
+  # Usage: https://conforma.dev/docs/policy/release_policy.html#step_image_registries_package
   allowed_step_image_registry_prefixes:
   - localhost:5000/
   - registry.local/namespace/repo/
@@ -32,19 +32,19 @@ rule_data:
   - docker.io/
   - quay.io/
 
-  # Usage: https://conforma.dev/docs/ec-policies/release_policy.html#java__no_foreign_dependencies
+  # Usage: https://conforma.dev/docs/policy/release_policy.html#java__no_foreign_dependencies
   # TODO: Document in the policy docs which values are expected here.
   allowed_java_component_sources:
   - redhat
   - rebuilt
 
-  # Usage: https://conforma.dev/docs/ec-policies/release_policy.html#external_parameters_package
+  # Usage: https://conforma.dev/docs/policy/release_policy.html#external_parameters_package
   pipeline_run_params:
   - git-repo
   - git-revision
   - output-image
 
-  # Usage: https://conforma.dev/docs/ec-policies/release_policy.html#labels__deprecated_labels
+  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__deprecated_labels
   deprecated_labels:
   - name: INSTALL
     replacement: install
@@ -53,7 +53,7 @@ rule_data:
   - name: Name
     replacement: name
 
-  # Usage: https://conforma.dev/docs/ec-policies/release_policy.html#labels__required_labels
+  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__required_labels
   required_labels:
   - name: architecture
     description: Architecture the software in the image should target.
@@ -64,7 +64,7 @@ rule_data:
   - name: vendor
     description: Name of the vendor.
 
-  # Usage: https://conforma.dev/docs/ec-policies/release_policy.html#labels__optional_labels
+  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__optional_labels
   optional_labels:
   - name: maintainer
     description: >-
@@ -73,22 +73,22 @@ rule_data:
   - name: summary
     description: A short description of the image.
 
-  # Usage: https://conforma.dev/docs/ec-policies/release_policy.html#labels__disallowed_inherited_labels
+  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__disallowed_inherited_labels
   disallowed_inherited_labels:
   - name: description
   - name: summary
 
-  # Usage: https://conforma.dev/docs/ec-policies/release_policy.html#labels__required_labels
+  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__required_labels
   fbc_required_labels:
   - name: build-date
     description: Date/Time image was built as RFC 3339 date-time.
 
-  # Usage: https://conforma.dev/docs/ec-policies/release_policy.html#labels__optional_labels
+  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__optional_labels
   fbc_optional_labels:
   - name: summary
     description: A short description of the image.
 
-  # https://conforma.dev/docs/ec-policies/release_policy.html#labels__disallowed_inherited_labels
+  # https://conforma.dev/docs/policy/release_policy.html#labels__disallowed_inherited_labels
   fbc_disallowed_inherited_labels:
   - name: description
   - name: summary

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/enterprise-contract/ec-policies
+module github.com/conforma/policy
 
 go 1.24.2
 

--- a/hack/validate-acceptable-bundles.sh
+++ b/hack/validate-acceptable-bundles.sh
@@ -47,7 +47,7 @@ function list_pipeline_bundles() {
         '."pipeline-bundles" | to_entries | .[] | [.key + "@" + .value[].digest] | .[]' | sort -u
 }
 
-origin_bundles="$(list_pipeline_bundles <(curl -s "https://raw.githubusercontent.com/enterprise-contract/ec-policies/main/${bundles_file}"))"
+origin_bundles="$(list_pipeline_bundles <(curl -s "https://raw.githubusercontent.com/conforma/policy/main/${bundles_file}"))"
 pr_bundles="$(list_pipeline_bundles "${bundles_file}")"
 new_bundles="$(comm -13 <(echo "${origin_bundles}") <(echo "${pr_bundles}"))"
 
@@ -68,8 +68,8 @@ for ref in ${new_bundles}; do
 
     # Evaluate the pipeline definition
     report="$(ec validate definition \
-        --policy git::https://github.com/enterprise-contract/ec-policies//policy/lib?ref=main \
-        --policy git::https://github.com/enterprise-contract/ec-policies//policy/pipeline?ref=main \
+        --policy git::https://github.com/conforma/policy//policy/lib?ref=main \
+        --policy git::https://github.com/conforma/policy//policy/pipeline?ref=main \
         --data git::https://github.com/release-engineering/rhtap-ec-policy//data \
         --file <(${TKN} bundle list -o json "${ref}" 2> /dev/null) \
         || true)"

--- a/policy/lib/result_helper_test.rego
+++ b/policy/lib/result_helper_test.rego
@@ -85,7 +85,7 @@ test_result_helper_with_term if {
 }
 
 test_result_helper_pkg_name if {
-	# "Normal" for ec-policies repo
+	# "Normal" for policy repo
 	lib.assert_equal("foo", lib._pkg_name(["data", "foo", "deny"]))
 	lib.assert_equal("foo", lib._pkg_name(["data", "foo", "warn"]))
 

--- a/policy/pipeline/artifacthub-pkg.yml
+++ b/policy/pipeline/artifacthub-pkg.yml
@@ -26,7 +26,7 @@ readme: |
   are a work in progress and not yet production ready.
 install: |
   `conftest pull oci::quay.io/enterprise-contracttract/ec-pipeline-policy:latest`
-homeURL: https://conforma.dev/docs/ec-policies/
+homeURL: https://conforma.dev/docs/policy/
 keywords:
   - opa
   - conftest

--- a/policy/release/artifacthub-pkg.yml
+++ b/policy/release/artifacthub-pkg.yml
@@ -27,10 +27,10 @@ readme: |
 install: |
   `conftest pull oci::quay.io/enterprise-contracttract/ec-release-policy:latest`
 
-  Configure your org-specific `--data` as necessary from [data/](https://github.com/enterprise-contract/ec-policies/tree/main/data)
+  Configure your org-specific `--data` as necessary from [data/](https://github.com/conforma/policy/tree/main/data)
 
   Run your conftest command: `conftest verify --data data/`
-homeURL: https://conforma.dev/docs/ec-policies/
+homeURL: https://conforma.dev/docs/policy/
 keywords:
   - opa
   - conftest

--- a/policy/release/github_certificate/github_certificate_test.rego
+++ b/policy/release/github_certificate/github_certificate_test.rego
@@ -27,10 +27,10 @@ test_gh_workflow_repository_mismatch if {
 	signatures := [{"certificate": good_cert}]
 	expected := {{
 		"code": "github_certificate.gh_workflow_repository",
-		"msg": "Repository \"lcarva/festoji\" not in allowed list: [\"ec-cli\", \"ec-policies\"]",
+		"msg": "Repository \"lcarva/festoji\" not in allowed list: [\"ec-cli\", \"policy\"]",
 	}}
 	lib.assert_equal_results(github_certificate.deny, expected) with input.image.signatures as signatures
-		with data.rule_data.allowed_gh_workflow_repos as ["ec-cli", "ec-policies"]
+		with data.rule_data.allowed_gh_workflow_repos as ["ec-cli", "policy"]
 }
 
 test_gh_workflow_ref_match if {

--- a/policy/release/trusted_task/trusted_task.rego
+++ b/policy/release/trusted_task/trusted_task.rego
@@ -6,7 +6,7 @@
 #   Trust is established by comparing the Task references found in the SLSA Provenance with a
 #   pre-defined list of trusted Tasks, which is expected to be provided as a data source that
 #   creates the `data.trusted_tasks` in the format demonstrated at
-#   https://github.com/enterprise-contract/ec-policies/blob/main/example/data/trusted_tekton_tasks.yml.
+#   https://github.com/conforma/policy/blob/main/example/data/trusted_tekton_tasks.yml.
 #   The list can be extended or customized using the `trusted_tasks` rule data key which is merged
 #   into the `trusted_tasks` data.
 #


### PR DESCRIPTION
This commit updates references from the
`enterprise-contract/ec-policies` repo to `conforma/policy`. Additionally, this commit updates references from `ec-policies` to `policy` in various examples, docs, etc.

Ref: EC-1113