### PR TITLE
Enforce only allowed images for pre-build script

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_pre_build_script_task.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_pre_build_script_task.adoc
@@ -1,0 +1,21 @@
+= Pre-build-script task checks Package
+
+This package verifies that the pre-build-script tasks in the attestation are executed in a controlled environment
+
+== Package Name
+
+* `pre_build_script_task`
+
+== Rules Included
+
+[#pre_build_script_task__pre_build_script_task_runner_image_allowed]
+=== link:#pre_build_script_task__pre_build_script_task_runner_image_allowed[Script runner image comes from allowed registry]
+
+Verify that the images used to run the pre-build script tasks come from a known set of trusted registries to reduce potential supply chain attacks. By default this policy defines trusted registries as registries that are fully maintained by Red Hat and only contain content produced by Red Hat. The list of allowed registries can be customized by setting the `allowed_registry_prefixes` list in the rule data.
+
+*Solution*: Make sure the image referenced in the parameter 'SCRIPT_RUNNER_IMAGE' comes from a trusted registry. The list of trusted registries is a configurable xref:ec-cli:ROOT:configuration.adoc#_data_sources[data source].
+
+* Rule type: [rule-type-indicator failure]#FAILURE#
+* FAILURE message: `Pre-Build-Script task runner image %q is from a disallowed registry`
+* Code: `pre_build_script_task.pre_build_script_task_runner_image_allowed`
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/pre_build_script_task/pre_build_script_task.rego#L20[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/packages/release_pre_build_script_task.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_pre_build_script_task.adoc
@@ -18,4 +18,4 @@ Verify that the images used to run the pre-build script tasks come from a known 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Pre-Build-Script task runner image %q is from a disallowed registry`
 * Code: `pre_build_script_task.pre_build_script_task_runner_image_allowed`
-* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/pre_build_script_task/pre_build_script_task.rego#L20[Source, window="_blank"]
+* https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/pre_build_script_task/pre_build_script_task.rego#L16[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora/docs/modules/ROOT/pages/release_policy.adoc
@@ -135,6 +135,7 @@ Rules included:
 * xref:packages/release_olm.adoc#olm__unmapped_references[OLM: Unmapped images in OLM bundle]        
 * xref:packages/release_olm.adoc#olm__unpinned_references[OLM: Unpinned images in OLM bundle]        
 * xref:packages/release_olm.adoc#olm__unpinned_snapshot_references[OLM: Unpinned images in input snapshot]        
+* xref:packages/release_pre_build_script_task.adoc#pre_build_script_task__pre_build_script_task_runner_image_allowed[Pre-build-script task checks: Script runner image comes from allowed registry]        
 * xref:packages/release_provenance_materials.adoc#provenance_materials__git_clone_source_matches_provenance[Provenance Materials: Git clone source matches materials provenance]        
 * xref:packages/release_provenance_materials.adoc#provenance_materials__git_clone_task_found[Provenance Materials: Git clone task found]        
 * xref:packages/release_quay_expiration.adoc#quay_expiration__expires_label[Quay expiration: Expires label]        
@@ -372,6 +373,9 @@ a| Check if the image has the expected labels set. The rules in this package dis
 
 | xref:packages/release_olm.adoc[olm]
 a| Checks for Operator Lifecycle Manager (OLM) bundles.
+
+| xref:packages/release_pre_build_script_task.adoc[pre_build_script_task]
+a| This package verifies that the pre-build-script tasks in the attestation are executed in a controlled environment
 
 | xref:packages/release_provenance_materials.adoc[provenance_materials]
 a| This package provides rules for verifying the contents of the materials section of the SLSA Provenance attestation.

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -68,6 +68,8 @@
 **** xref:packages/release_olm.adoc#olm__unmapped_references[Unmapped images in OLM bundle]
 **** xref:packages/release_olm.adoc#olm__unpinned_references[Unpinned images in OLM bundle]
 **** xref:packages/release_olm.adoc#olm__unpinned_snapshot_references[Unpinned images in input snapshot]
+*** xref:packages/release_pre_build_script_task.adoc[Pre-build-script task checks]
+**** xref:packages/release_pre_build_script_task.adoc#pre_build_script_task__pre_build_script_task_runner_image_allowed[Script runner image comes from allowed registry]
 *** xref:packages/release_provenance_materials.adoc[Provenance Materials]
 **** xref:packages/release_provenance_materials.adoc#provenance_materials__git_clone_source_matches_provenance[Git clone source matches materials provenance]
 **** xref:packages/release_provenance_materials.adoc#provenance_materials__git_clone_task_found[Git clone task found]

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -171,6 +171,14 @@ build_tasks(attestation) := [task |
 	count(image_digest) > 0
 ]
 
+pre_build_tasks(attestation) := [task |
+	some task in tasks(attestation)
+	some pre_build_task_name in _pre_build_task_names
+	task_name(task) == pre_build_task_name
+]
+
+_pre_build_task_names := ["run-script-oci-ta"]
+
 # return the tasks that have "TEST_OUTPUT" as a result
 tasks_output_result(attestation) := [task |
 	some task in tasks(attestation)

--- a/policy/lib/tekton/task_test.rego
+++ b/policy/lib/tekton/task_test.rego
@@ -327,6 +327,11 @@ test_build_task_not_found if {
 	count(tekton.build_tasks(missing_results)) == 0
 }
 
+test_pre_build_tasks if {
+	expected := [_pre_build_task]
+	lib.assert_equal(expected, tekton.pre_build_tasks(_good_attestation))
+}
+
 test_multiple_build_tasks if {
 	task1 := json.patch(_good_build_task, [{
 		"op": "replace",
@@ -644,6 +649,11 @@ _time_based_required_tasks := [
 	},
 ]
 
+_pre_build_task := {
+	"ref": {"kind": "Task", "name": "run-script-oci-ta", "bundle": _bundle},
+	"invocation": {"parameters": {"HERMETIC": "true"}},
+}
+
 _good_build_task := {
 	"results": [
 		{"name": "IMAGE_URL", "value": "registry/repo"},
@@ -671,7 +681,7 @@ _good_source_build_task := {
 
 _good_attestation := {"statement": {"predicate": {
 	"buildType": lib.tekton_pipeline_run,
-	"buildConfig": {"tasks": [_good_build_task, _good_git_clone_task, _good_source_build_task]},
+	"buildConfig": {"tasks": [_good_build_task, _good_git_clone_task, _good_source_build_task, _pre_build_task]},
 }}}
 
 slsav1_attestation_local_spec := {

--- a/policy/release/pre_build_script_task/pre_build_script_task.rego
+++ b/policy/release/pre_build_script_task/pre_build_script_task.rego
@@ -1,0 +1,58 @@
+#
+# METADATA
+# title: Pre-build-script task checks
+# description: >-
+#   This package verifies that the pre-build-script tasks in the
+#   attestation are executed in a controlled environment
+#
+package pre_build_script_task
+
+import rego.v1
+
+import data.lib
+import data.lib.image
+import data.lib.tekton
+
+_pre_build_script_task_names := ["run-script-oci-ta"]
+
+# METADATA
+# title: Script runner image comes from allowed registry
+# description: >-
+#   Verify that the images used to run the pre-build script tasks come from a known
+#   set of trusted registries to reduce potential supply chain attacks. By default this
+#   policy defines trusted registries as registries that are fully maintained by Red
+#   Hat and only contain content produced by Red Hat. The list of allowed registries
+#   can be customized by setting the `allowed_registry_prefixes` list in the rule data.
+# custom:
+#   short_name: pre_build_script_task_runner_image_allowed
+#   failure_msg: Pre-Build-Script task runner image %q is from a disallowed registry
+#   solution: >-
+#     Make sure the image referenced in the parameter 'SCRIPT_RUNNER_IMAGE' comes from
+#     a trusted registry. The list of trusted registries is a configurable
+#     xref:ec-cli:ROOT:configuration.adoc#_data_sources[data source].
+#   collections:
+#   - redhat
+#   depends_on:
+#   - attestation_type.known_attestation_type
+#   - base_image_registries.allowed_registries_provided
+#
+deny contains result if {
+	some attestation in lib.pipelinerun_attestations
+	some task in tekton.tasks(attestation)
+	some pre_build_task_name in _pre_build_script_task_names
+	tekton.task_name(task) == pre_build_task_name
+	image_ref := tekton.task_param(task, _pre_build_script_runner_image_param)
+	not _image_ref_permitted(image_ref)
+	repo := image.parse(image_ref).repo
+	result := lib.result_helper_with_term(rego.metadata.chain(), [image_ref], repo)
+}
+
+_pre_build_script_runner_image_param := "SCRIPT_RUNNER_IMAGE"
+
+_image_ref_permitted(image_ref) if {
+	allowed_prefixes := lib.rule_data(_rule_data_allowed_registries_key)
+	some allowed_prefix in allowed_prefixes
+	startswith(image_ref, allowed_prefix)
+}
+
+_rule_data_allowed_registries_key := "allowed_registry_prefixes"

--- a/policy/release/pre_build_script_task/pre_build_script_task.rego
+++ b/policy/release/pre_build_script_task/pre_build_script_task.rego
@@ -13,8 +13,6 @@ import data.lib
 import data.lib.image
 import data.lib.tekton
 
-_pre_build_script_task_names := ["run-script-oci-ta"]
-
 # METADATA
 # title: Script runner image comes from allowed registry
 # description: >-
@@ -38,9 +36,7 @@ _pre_build_script_task_names := ["run-script-oci-ta"]
 #
 deny contains result if {
 	some attestation in lib.pipelinerun_attestations
-	some task in tekton.tasks(attestation)
-	some pre_build_task_name in _pre_build_script_task_names
-	tekton.task_name(task) == pre_build_task_name
+	some task in tekton.pre_build_tasks(attestation)
 	image_ref := tekton.task_param(task, _pre_build_script_runner_image_param)
 	not _image_ref_permitted(image_ref)
 	repo := image.parse(image_ref).repo

--- a/policy/release/pre_build_script_task/pre_build_script_task_test.rego
+++ b/policy/release/pre_build_script_task/pre_build_script_task_test.rego
@@ -1,0 +1,51 @@
+package pre_build_script_task_test
+
+import rego.v1
+
+import data.lib
+import data.pre_build_script_task
+
+test_good_pre_build_script_tasks if {
+	lib.assert_empty(pre_build_script_task.deny) with input.attestations as [_good_attestation]
+		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+}
+
+test_disallowed_script_task_runner_image if {
+	expected := {{
+		"code": "pre_build_script_task.pre_build_script_task_runner_image_allowed",
+		"msg": "Pre-Build-Script task runner image \"malicious.io/img:latest@sha256:abc\" is from a disallowed registry",
+		"term": "malicious.io/img",
+	}}
+
+	disallowed_image := json.patch(_good_attestation, [{
+		"op": "add",
+		"path": "/statement/predicate/buildConfig/tasks/0/invocation/parameters/SCRIPT_RUNNER_IMAGE",
+		"value": "malicious.io/img:latest@sha256:abc",
+	}])
+	lib.assert_equal_results(expected, pre_build_script_task.deny) with input.attestations as [disallowed_image]
+		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+}
+
+_good_attestation := {"statement": {"predicate": {
+	"buildType": lib.tekton_pipeline_run,
+	"buildConfig": {"tasks": [
+		{
+			"name": "run-script-oci-ta-1",
+			"ref": {"kind": "Task", "name": "run-script-oci-ta", "bundle": "reg.img/spam@sha256:abc"},
+			"invocation": {"parameters": {
+				"SCRIPT": "/some-script.sh",
+				"SCRIPT_RUNNER_IMAGE": "registry.redhat.io/ubi7:latest@sha256:abc",
+			}},
+		},
+		{
+			"name": "run-script-oci-ta-2",
+			"ref": {"kind": "Task", "name": "run-script-oci-ta", "bundle": "reg.img/spam@sha256:abc"},
+			"invocation": {"parameters": {
+				"SCRIPT": "/some-other-script.sh",
+				"SCRIPT_RUNNER_IMAGE": "quay.io/konflux-ci/bazel6-ubi9:latest@sha256:bcd",
+			}},
+		},
+	]},
+}}}
+
+_allowed_registries := ["registry.redhat.io/", "quay.io/konflux-ci/bazel6-ubi9"]

--- a/policy/release/trusted_task/trusted_task.rego
+++ b/policy/release/trusted_task/trusted_task.rego
@@ -347,18 +347,11 @@ _trusted_build_digests contains digest if {
 # task so the build task can include the additional base image in the SBOM.
 _trusted_build_digests contains digest if {
 	some attestation in lib.pipelinerun_attestations
-	some task in _pre_build_run_script_tasks(attestation)
+	some task in tekton.pre_build_tasks(attestation)
 	tekton.is_trusted_task(task)
 	runner_image_result_value := tekton.task_result(task, _pre_build_run_script_runner_image_result)
 	some digest in _digests_from_values({runner_image_result_value})
 }
-
-_pre_build_run_script_tasks(attestation) := [task |
-	some task in tekton.tasks(attestation)
-	tekton.task_ref(task).name == _pre_build_run_script_task_name
-]
-
-_pre_build_run_script_task_name := "run-script-oci-ta"
 
 _pre_build_run_script_runner_image_result := "SCRIPT_RUNNER_IMAGE_REFERENCE"
 


### PR DESCRIPTION
Create a new rule that verifies that the parameter SCRIPT_RUNNER_IMAGE
contains an image reference coming only from allowed repositories.
It uses the 'allowed_registry_prefixes' rule_data as list of
allowed registries, that is also used in the base image checks.

Ref: https://issues.redhat.com/browse/EC-1241