### PR TITLE
Allow pre build script runner image digest

### DIFF
--- a/policy/release/trusted_task/trusted_task.rego
+++ b/policy/release/trusted_task/trusted_task.rego
@@ -341,6 +341,27 @@ _trusted_build_digests contains digest if {
 	digest != ""
 }
 
+# If an image is included in the "SCRIPT_RUNNER_IMAGE_REFERENCE" task result
+# produced by a trusted "run-script-oci-ta" task, then we permit it. This
+# image ref gets placed in the ADDITIONAL_BASE_IMAGES task param for the build
+# task so the build task can include the additional base image in the SBOM.
+_trusted_build_digests contains digest if {
+	some attestation in lib.pipelinerun_attestations
+	some task in _pre_build_run_script_tasks(attestation)
+	tekton.is_trusted_task(task)
+	runner_image_result_value := tekton.task_result(task, _pre_build_run_script_runner_image_result)
+	some digest in _digests_from_values({runner_image_result_value})
+}
+
+_pre_build_run_script_tasks(attestation) := [task |
+	some task in tekton.tasks(attestation)
+	tekton.task_ref(task).name == _pre_build_run_script_task_name
+]
+
+_pre_build_run_script_task_name := "run-script-oci-ta"
+
+_pre_build_run_script_runner_image_result := "SCRIPT_RUNNER_IMAGE_REFERENCE"
+
 _digests_from_values(values) := {digest |
 	some value in values
 	some pattern in _digest_patterns

--- a/policy/release/trusted_task/trusted_task_test.rego
+++ b/policy/release/trusted_task/trusted_task_test.rego
@@ -325,6 +325,56 @@ test_data_errors if {
 	lib.assert_equal_results(trusted_task.deny, expected) with data.trusted_tasks as bad_data
 }
 
+################################
+# _trusted_build_digests tests #
+################################
+
+_mock_run_script_result := {
+	"name": "SCRIPT_RUNNER_IMAGE_REFERENCE",
+	"value": "registry.io/runner/image@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+	"type": "string",
+}
+
+_mock_att_with_task(task) := {"statement": {"predicate": {
+	"buildType": lib.tekton_pipeline_run,
+	"buildConfig": {"tasks": [task]},
+}}}
+
+test_trusted_build_digests_from_run_script_result if {
+	# A digest from the SCRIPT_RUNNER_IMAGE_REFERENCE task result in the run-script-oci-ta
+	# task appears in _trusted_build_digests if the task is considered a trusted task
+	attestation := _mock_att_with_task({
+		"ref": {"name": "run-script-oci-ta", "bundle": "registry.local/trusty:1.0@sha256:digest"},
+		"results": [_mock_run_script_result],
+	})
+	expected := {"sha256:1111111111111111111111111111111111111111111111111111111111111111"}
+	lib.assert_equal(trusted_task._trusted_build_digests, expected) with input.attestations as [attestation]
+		with data.trusted_tasks as trusted_tasks_data
+}
+
+test_trusted_build_digests_from_run_script_untrusted if {
+	# A digest from the SCRIPT_RUNNER_IMAGE_REFERENCE task result in the run-script-oci-ta
+	# task does not appear in _trusted_build_digests if the task is not considered a trusted task
+	attestation := _mock_att_with_task({
+		"ref": {"name": "run-script-oci-ta", "bundle": "registry.local/unknown:1.0@sha256:digest"},
+		"results": [_mock_run_script_result],
+	})
+	lib.assert_empty(trusted_task._trusted_build_digests) with input.attestations as [attestation]
+		with data.trusted_tasks as trusted_tasks_data
+}
+
+test_trusted_build_digests_from_run_script_no_result if {
+	# A digest from the some other task result in the run-script-oci-ta task does not appear
+	# in _trusted_build_digests even if the task is not considered a trusted task
+	results := json.patch(_mock_run_script_result, [{"op": "add", "path": "/name", "value": "SOME_OTHER_NAME"}])
+	attestation := _mock_att_with_task({
+		"ref": {"name": "run-script-oci-ta", "bundle": "registry.local/trusty:1.0@sha256:digest"},
+		"results": [results],
+	})
+	lib.assert_equal(trusted_task._trusted_build_digests, set()) with input.attestations as [attestation]
+		with data.trusted_tasks as trusted_tasks_data
+}
+
 #########################################
 # Pipeline Tasks using bundles resolver #
 #########################################


### PR DESCRIPTION
Make sure the new `run-script-oci-ta` task can pass an image ref and digest via the ADDITIONAL_BASE_IMAGES param to the build task without producing a violation.

See commit messages for more details. Includes some additional test coverage for the _trusted_build_digest rules.

Assisted-by: Claude 3.7 Sonnet (with Cursor)
Ref: https://issues.redhat.com/browse/EC-1303