### PR TITLE
Update doc links to new package pages

### DIFF
--- a/example/data/required_tasks.yml
+++ b/example/data/required_tasks.yml
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Usage: https://conforma.dev/docs/policy/release_policy.html#tasks_package
+# Usage: https://conforma.dev/docs/policy/packages/release_tasks.html
 pipeline-required-tasks:
   fbc:
     - effective_on: "2023-08-31T00:00:00Z"
@@ -85,7 +85,7 @@ pipeline-required-tasks:
         - show-sbom
         - summary
 
-# Usage: https://conforma.dev/docs/policy/release_policy.html#tasks_package
+# Usage: https://conforma.dev/docs/policy/packages/release_tasks.html
 required-tasks:
   - effective_on: "2023-08-31T00:00:00Z"
     tasks:

--- a/example/data/rule_data.yml
+++ b/example/data/rule_data.yml
@@ -16,12 +16,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 rule_data:
-  # Usage: https://conforma.dev/docs/ec-policies/release_policy.html#git_branch__git_branch
+  # Usage: https://conforma.dev/docs/policy/packages/release_git_branch.html#git_branch__git_branch
   allowed_branch_patterns:
   - ^refs/heads/main$
   - ^refs/heads/release-v[\d\.]+$
 
-  # Usage: https://conforma.dev/docs/policy/release_policy.html#base_image_registries__allowed_registries_provided
+  # Usage: https://conforma.dev/docs/policy/packages/release_base_image_registries.html#base_image_registries__allowed_registries_provided
   allowed_registry_prefixes:
   - localhost:5000/
   - registry.local/namespace/repo/
@@ -29,7 +29,7 @@ rule_data:
   - docker.io/
   - registry.access.redhat.com
 
-  # Usage: https://conforma.dev/docs/policy/release_policy.html#step_image_registries_package
+  # Usage: https://conforma.dev/docs/policy/packages/task_step_image_registries.html
   allowed_step_image_registry_prefixes:
   - localhost:5000/
   - registry.local/namespace/repo/
@@ -43,13 +43,13 @@ rule_data:
   - redhat
   - rebuilt
 
-  # Usage: https://conforma.dev/docs/policy/release_policy.html#external_parameters_package
+  # Usage: https://conforma.dev/docs/policy/packages/release_external_parameters.html
   pipeline_run_params:
   - git-repo
   - git-revision
   - output-image
 
-  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__deprecated_labels
+  # Usage: https://conforma.dev/docs/policy/packages/release_labels.html#labels__deprecated_labels
   deprecated_labels:
   - name: INSTALL
     replacement: install
@@ -58,7 +58,7 @@ rule_data:
   - name: Name
     replacement: name
 
-  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__required_labels
+  # Usage: https://conforma.dev/docs/policy/packages/release_labels.html#labels__required_labels
   required_labels:
   - name: architecture
     description: Architecture the software in the image should target.
@@ -69,7 +69,7 @@ rule_data:
   - name: vendor
     description: Name of the vendor.
 
-  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__optional_labels
+  # Usage: https://conforma.dev/docs/policy/packages/release_labels.html#labels__optional_labels
   optional_labels:
   - name: maintainer
     description: >-
@@ -78,22 +78,22 @@ rule_data:
   - name: summary
     description: A short description of the image.
 
-  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__disallowed_inherited_labels
+  # Usage: https://conforma.dev/docs/policy/packages/release_labels.html#labels__disallowed_inherited_labels
   disallowed_inherited_labels:
   - name: description
   - name: summary
 
-  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__required_labels
+  # Usage: https://conforma.dev/docs/policy/packages/release_labels.html#labels__required_labels
   fbc_required_labels:
   - name: build-date
     description: Date/Time image was built as RFC 3339 date-time.
 
-  # Usage: https://conforma.dev/docs/policy/release_policy.html#labels__optional_labels
+  # Usage: https://conforma.dev/docs/policy/packages/release_labels.html#labels__optional_labels
   fbc_optional_labels:
   - name: summary
     description: A short description of the image.
 
-  # https://conforma.dev/docs/policy/release_policy.html#labels__disallowed_inherited_labels
+  # https://conforma.dev/docs/policy/packages/release_labels.html#labels__disallowed_inherited_labels
   fbc_disallowed_inherited_labels:
   - name: description
   - name: summary


### PR DESCRIPTION
In some places there are links to packages in the docs which became outdated following the split up of policy pages.

Ref: https://issues.redhat.com/browse/EC-984