### PR TITLE
Exclude image index from 'pre build image in SBOM'

### DIFF
--- a/policy/release/pre_build_script_task/pre_build_script_task.rego
+++ b/policy/release/pre_build_script_task/pre_build_script_task.rego
@@ -106,6 +106,9 @@ deny contains result if {
 #   - redhat
 #
 deny contains result if {
+	# This check does not apply to the image index for multi-arch builds
+	# because its sbom is different to the sbom for the per-arch images
+	not image.is_image_index(input.image.ref)
 	some pre_build_image in _script_runner_image_refs
 	image.parse(pre_build_image)
 	not _is_image_in_sbom(pre_build_image)

--- a/policy/release/pre_build_script_task/pre_build_script_task_test.rego
+++ b/policy/release/pre_build_script_task/pre_build_script_task_test.rego
@@ -9,6 +9,29 @@ test_good_pre_build_script_tasks if {
 	# regal ignore:line-length
 	lib.assert_empty(pre_build_script_task.deny) with input.attestations as [_good_attestation, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029"}
+
+	good_attestation_with_image_index := json.patch(_good_attestation, [{
+		"op": "add",
+		"path": "/statement/predicate/buildConfig/tasks/2",
+		"value": {
+			"name": "run-script-oci-ta-3",
+			"ref": {"kind": "Task", "name": "run-script-oci-ta", "bundle": "reg.img/spam@sha256:abc"},
+			"invocation": {"parameters": {
+				"SCRIPT": "/some-other-script.sh",
+				"SCRIPT_RUNNER_IMAGE": "quay.io/konflux-ci/bazel6-ubi9@sha256:not-in-sbom",
+			}},
+			"results": [{"name": "SCRIPT_RUNNER_IMAGE_REFERENCE", "value": "quay.io/konflux-ci/bazel6-ubi9@sha256:not-in-sbom"}],
+		},
+	}])
+
+	image_manifest := {"mediaType": "application/vnd.oci.image.index.v1+json"}
+
+	# regal ignore:line-length
+	lib.assert_empty(pre_build_script_task.deny) with input.attestations as [good_attestation_with_image_index, _cyclonedx_sbom_attestation]
+		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+		with ec.oci.descriptor as image_manifest
+		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029"}
 }
 
 test_disallowed_script_task_runner_image if {
@@ -27,6 +50,7 @@ test_disallowed_script_task_runner_image if {
 	# regal ignore:line-length
 	lib.assert_equal_results(expected, pre_build_script_task.deny) with input.attestations as [disallowed_image, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029"}
 }
 
 test_pre_build_image_not_in_task_result if {
@@ -43,16 +67,19 @@ test_pre_build_image_not_in_task_result if {
 	# regal ignore:line-length
 	lib.assert_equal_results(expected, pre_build_script_task.deny) with input.attestations as [attestation_missing_task_result, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029"}
 }
 
 test_pre_build_image_in_sbom if {
 	# regal ignore:line-length
 	lib.assert_empty(pre_build_script_task.deny) with input.attestations as [_good_attestation, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029"}
 
 	# regal ignore:line-length
 	lib.assert_empty(pre_build_script_task.deny) with input.attestations as [_good_attestation, _spdx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029"}
 }
 
 test_pre_build_image_in_sbom_ignoring_tag if {
@@ -73,10 +100,12 @@ test_pre_build_image_in_sbom_ignoring_tag if {
 	# regal ignore:line-length
 	lib.assert_empty(pre_build_script_task.deny) with input.attestations as [good_attestation_with_tag_in_image_ref, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029"}
 
 	# regal ignore:line-length
 	lib.assert_empty(pre_build_script_task.deny) with input.attestations as [good_attestation_with_tag_in_image_ref, _spdx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029"}
 }
 
 test_pre_build_image_not_in_sbom if {
@@ -93,6 +122,7 @@ test_pre_build_image_not_in_sbom if {
 	# regal ignore:line-length
 	lib.assert_equal_results(expected, pre_build_script_task.deny) with input.attestations as [_good_attestation, incomplete_cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029"}
 
 	incomplete_spdx_sbom_attestation := json.patch(_spdx_sbom_attestation, [{
 		"op": "remove",
@@ -102,6 +132,7 @@ test_pre_build_image_not_in_sbom if {
 	# regal ignore:line-length
 	lib.assert_equal_results(expected, pre_build_script_task.deny) with input.attestations as [_good_attestation, incomplete_spdx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029"}
 }
 
 test_pre_build_image_reference_is_not_valid if {
@@ -120,6 +151,7 @@ test_pre_build_image_reference_is_not_valid if {
 	# regal ignore:line-length
 	lib.assert_equal_results(expected, pre_build_script_task.deny) with input.attestations as [invalid_prebuild_img_attestation, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
+		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029"}
 }
 
 _good_attestation := {"statement": {"predicate": {


### PR DESCRIPTION
This commit reduces the scope of the rule
'pre_build_script_task_runner_image_in_sbom' by filtering out image indexes from the check.
This is because if we ensure that all the references in an image index are in the SBOM, we don't need to check the image index itself.