### PR TITLE
fix(scripts): update repository names

### DIFF
--- a/hack/update-bundles.sh
+++ b/hack/update-bundles.sh
@@ -82,7 +82,7 @@ function exclusions() {
 }
 
 function repo_name() {
-  echo "ec-$1-policy"
+  echo "${1//_/-}-policy"
 }
 
 tmp_oci_dirs=()


### PR DESCRIPTION
This commit removes the `ec-` prefix from quay repository names and ensures that underscores are replaced by dashes in bundle names.

Co-authored-by: claude-4-sonnet
Ref: EC-1349