### PR TITLE
Fix typo in hyperlink on conforma.dev/docs/policy

### DIFF
--- a/antora/docs/modules/ROOT/pages/index.adoc
+++ b/antora/docs/modules/ROOT/pages/index.adoc
@@ -18,7 +18,7 @@ xref:pipeline_policy.adoc[Pipeline Policy].
 
 == Code
 
-* https://github.com/conforma/plicy[github.com/conforma/policy]
+* https://github.com/conforma/policy[github.com/conforma/policy]
 * https://github.com/conforma/cli[github.com/conforma/cli]
 * https://github.com/enterprise-contract[github.com/enterprise-contract]
 * https://github.com/konflux-ci[github.com/konflux-ci]


### PR DESCRIPTION
The link of github.com/conforma/policy when clicked, leads to https://github.com/conforma/plicy (broken address).

Ref: https://issues.redhat.com/browse/KFLUXSPRT-4010