### PR TITLE
Disable the rpm uniqueness check once again

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_rpm_packages.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_rpm_packages.adoc
@@ -16,5 +16,5 @@ Check if there is more than one version of the same RPM installed across differe
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Multiple versions of the %q RPM were found: %s`
 * Code: `rpm_packages.unique_version`
-* Effective from: `2025-06-28T00:00:00Z`
+* Effective from: `2025-10-01T00:00:00Z`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_packages/rpm_packages.rego#L17[Source, window="_blank"]

--- a/policy/release/rpm_packages/rpm_packages.rego
+++ b/policy/release/rpm_packages/rpm_packages.rego
@@ -25,8 +25,8 @@ import data.lib.tekton
 #   failure_msg: 'Multiple versions of the %q RPM were found: %s'
 #   collections:
 #   - redhat
-#   # Pushed back due to https://issues.redhat.com/browse/EC-1232
-#   effective_on: 2025-06-28T00:00:00Z
+#   # Pushed back again due to https://issues.redhat.com/browse/EC-1354
+#   effective_on: 2025-10-01T00:00:00Z
 #
 deny contains result if {
 	image.is_image_index(input.image.ref)


### PR DESCRIPTION
Since this causes bogus violations for some teams, and there's no solid workaround, let's disable it again while we work on a solution, (rather than force all impacted teams to create custom excludes in the ECP policy.yaml).

See the Jira for a longer explanation.

I chose the date to give enough time to resolve EC-1354.

Ref: https://issues.redhat.com/browse/EC-1354