### PR TITLE
Remove unsubstituted format string `%s` from solution field of hermetic_task.hermetic rule

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_hermetic_task.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_hermetic_task.adoc
@@ -13,7 +13,7 @@ This package verifies that all the tasks in the attestation that are required to
 
 Verify the task in the PipelineRun attestation was invoked with the proper parameters to make the task execution hermetic.
 
-*Solution*: Make sure the task '%s' has the input parameter 'HERMETIC' set to 'true'.
+*Solution*: Make sure the task has the input parameter 'HERMETIC' set to 'true'.
 
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Task '%s' was not invoked with the hermetic parameter set`

--- a/policy/release/hermetic_task/hermetic_task.rego
+++ b/policy/release/hermetic_task/hermetic_task.rego
@@ -23,7 +23,7 @@ import data.lib.tekton
 #   failure_msg: >-
 #     Task '%s' was not invoked with the hermetic parameter set
 #   solution: >-
-#     Make sure the task '%s' has the input parameter 'HERMETIC' set to
+#     Make sure the task has the input parameter 'HERMETIC' set to
 #     'true'.
 #   collections:
 #   - redhat


### PR DESCRIPTION
* Conforma log rendered the error:
```
["attestation_type.known_attestation_type"],"description": "Verify the task in the PipelineRun attestation was invoked with the proper parameters to make the task execution hermetic. To exclude this rule add \"hermetic_task.hermetic\" to the `exclude` section of the policy configuration.",awk: cmd. line:1: (FILENAME=- FNR=64634) fatal: not enough arguments to satisfy format string
	`"solution": "Make sure the task '%s' has the input parameter 'HERMETIC' set to 'true'.",'
	                                  ^ ran out for this one 
```
* I **_suspect_** that its because the solution fields of Rego rules are not substituted with the values from the "lib.result_helper" function. This substituion works only with the "failure_msg field.
* So, I removed the `%s` field from the solution field.

resolves: EC-1356