### PR TITLE
Match kebab or snake case in sbom purl

### DIFF
--- a/policy/release/pre_build_script_task/pre_build_script_task.rego
+++ b/policy/release/pre_build_script_task/pre_build_script_task.rego
@@ -152,7 +152,7 @@ _purls_from_sbom(s) := purls if {
 		some pkg in s.packages
 		some ref in pkg.externalRefs
 		ref.referenceType == "purl"
-		ref.referenceCategory == "PACKAGE-MANAGER"
+		ref.referenceCategory in {"PACKAGE-MANAGER", "PACKAGE_MANAGER"}
 	}
 	count(purls) > 0
 }

--- a/policy/release/pre_build_script_task/pre_build_script_task_test.rego
+++ b/policy/release/pre_build_script_task/pre_build_script_task_test.rego
@@ -194,7 +194,8 @@ _spdx_sbom_attestation := {"statement": {
 			"referenceLocator": "pkg:oci/ubi7@sha256:bcd?repository_url=registry.redhat.io/ubi7",
 		},
 		{
-			"referenceCategory": "PACKAGE-MANAGER",
+			# Intentionally different referenceCategory here
+			"referenceCategory": "PACKAGE_MANAGER",
 			"referenceType": "purl",
 			"referenceLocator": "pkg:oci/bazel6-ubi9@sha256:def?repository_url=quay.io/konflux-ci/bazel6-ubi9",
 		},


### PR DESCRIPTION
IIUC there was a recent mobster change that introduced the snake case version of the key. I'm not clear on which one is preferred, (which may be important depending on other consumers of this data), but let's assume the newer one is better.

Right now we have do some SBOMs with both, so in the interest of unblocking people who started getting a
pre_build_script_task_runner_image_in_sbom violation, let's match both until further notice.

Ref: https://issues.redhat.com/browse/KFLUXSPRT-4463