### PR TITLE
Restore PR #1461

### DIFF
--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -35,8 +35,6 @@ taskrun_att_build_types := {
 # with test_ is treated as though it was a test.)
 task_test_result_name := "TEST_OUTPUT"
 
-task_test_image_result_name := "IMAGES_PROCESSED"
-
 slsa_provenance_attestations := [att |
 	some att in input.attestations
 	att.statement.predicateType in {slsa_provenance_predicate_type_v1, slsa_provenance_predicate_type_v02}
@@ -121,8 +119,6 @@ unmarshal(raw) := value if {
 # (Don't call it test_results since test_ means a unit test)
 # First find results using the new task result name
 results_from_tests := results_named(task_test_result_name)
-
-images_processed_results_from_tests := results_named(task_test_image_result_name)
 
 # Check for a task by name. Return the task if found
 task_in_pipelinerun(name) := task if {

--- a/policy/release/test/test_test.rego
+++ b/policy/release/test/test_test.rego
@@ -448,7 +448,7 @@ test_wrong_attestation_type if {
 test_all_image_processed if {
 	# regal ignore:line-length
 	digests_processed := {"image": {"digests": ["sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"]}}
-	pipeline_run := lib_test.att_mock_helper_ref(lib.task_test_image_result_name, digests_processed, "success_23", _bundle)
+	pipeline_run := lib_test.att_mock_helper_ref("IMAGES_PROCESSED", digests_processed, "success_23", _bundle)
 	attestations := [
 		pipeline_run,
 		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "errored_1", _bundle),
@@ -460,7 +460,7 @@ test_all_image_processed if {
 
 test_all_images_not_processed if {
 	digests_processed := {"image": {"digests": ["sha256:wrongDigest"]}}
-	pipeline_run := lib_test.att_mock_helper_ref(lib.task_test_image_result_name, digests_processed, "success_23", _bundle)
+	pipeline_run := lib_test.att_mock_helper_ref("IMAGES_PROCESSED", digests_processed, "success_23", _bundle)
 
 	attestations := [
 		pipeline_run,
@@ -473,6 +473,25 @@ test_all_images_not_processed if {
 		"msg": "Test 'success_23' did not process image with digest 'sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb'.",
 		"term": "success_23",
 	}}) with input.attestations as attestations
+		with input.image.ref as _bundle
+}
+
+test_all_images_matrix_tasks if {
+	# Matrix task scenario: same task name and bundle but different digests processed by each instance
+	digests_task1 := {"image": {"digests": ["sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"]}}
+	digests_task2 := {"image": {"digests": ["sha256:otherDigest"]}}
+
+	matrix_task1 := lib_test.att_mock_helper_ref("IMAGES_PROCESSED", digests_task1, "matrix-test", _bundle)
+	matrix_task2 := lib_test.att_mock_helper_ref("IMAGES_PROCESSED", digests_task2, "matrix-test", _bundle)
+
+	attestations := [
+		matrix_task1,
+		matrix_task2,
+		lib_test.att_mock_helper_ref(lib.task_test_result_name, {"result": "SUCCESS"}, "matrix-test", _bundle),
+	]
+
+	# Should pass because the grouped results combine digests from both matrix task instances
+	lib.assert_empty(test.deny) with input.attestations as attestations
 		with input.image.ref as _bundle
 }
 


### PR DESCRIPTION
This commit reintroduces the changes from #1461

They were reverted because of KFLUXSPRT-4562, but now the root cause has been addressed in the commit referenced below so we can safely re-apply them.

Ref: https://github.com/konflux-ci/build-definitions/pull/2637
Ref: https://issues.redhat.com/browse/KFLUXSPRT-4562