### PR TITLE
Tweak gemini prompt for release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,13 +101,17 @@ jobs:
               "autoAccept": true
             }
           prompt: |
-            Make a list of all notable changes since the tag ${{needs.get_info.outputs.latest_tag}}
-            and categorize it nicely with emojis, output as Markdown and a
-            one liner of the change. Add a jira link for each change if 
-            specified in the commit message. put the link in the begining 
-            of the line.
-            Preface the release notes with a brief summary of the release.
+            Make a release notes based on all notable changes since the tag
+            ${{needs.get_info.outputs.latest_tag}}.
+            Categorize it nicely with emojis, output as Markdown.
+            For each change that you mention in the release notes:
+              - Summarize the change in one line
+              - Put jira link in the beginning of the line, if the change has a
+                jira link in the commit message
+            Include all changes that have jira link in the commit message.
             Don't create a title for the release.
+            Preface the release notes with a brief summary of the release.
+            The summary should also refer to changes in policies and policy rules.
             Also save the release notes in a file named "release-notes.md".
 
       - name: Upload artifact


### PR DESCRIPTION
- Attempt to make the direction to include a link to Jira clearer
- Include all changes with Jira link
- Make the release summary oriented to changes in policy and rules