### PR TITLE
Workaround dupe entries in trusted task list

### DIFF
--- a/policy/lib/tekton/trusted.rego
+++ b/policy/lib/tekton/trusted.rego
@@ -96,8 +96,14 @@ _task_expires_on(task) := expires if {
 	ref := task_ref(task)
 	records := _trusted_tasks[ref.key]
 
-	some record in records
-	record.ref == ref.pinned_ref
+	matching_records := [r |
+		some r in records
+		r.ref == ref.pinned_ref
+	]
+
+	# Avoid an "eval_conflict_error: functions must not produce multiple
+	# outputs..." error if the data has duplicate records for this ref
+	record := matching_records[0]
 
 	expires = time.parse_rfc3339_ns(record.expires_on)
 }


### PR DESCRIPTION
It should not happen, but just in case there are duplicate entries, let's handle it without throwing errors.

Note: I considered sorting by the expiration date and pick the earliest date, but decided that would make it seem like we intend to support the duplicate records, which is not the case. Let's keep this workaround is as minimal as possible.

This is the duplicate record we're seeing right now in the acceptable bundles data:

    oci://quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.2:
      ...
      - expires_on: "2025-10-11T00:00:00Z"
        ref: sha256:b424894fc8e806c12658daa565b835fd2d66e7f7608afc47529eb7b410f030d7
      ...
      - expires_on: "2025-09-13T00:00:00Z"
        ref: sha256:b424894fc8e806c12658daa565b835fd2d66e7f7608afc47529eb7b410f030d7

(How it got there is not clear, but we should figure it out.)

Ref: https://issues.redhat.com/browse/KFLUXSPRT-4609