### PR TITLE
Fail release workflow if release notes are missing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,6 +118,7 @@ jobs:
         with:
           name: release-notes
           path: release-notes.md
+          if-no-files-found: error
 
 
   create_release:


### PR DESCRIPTION
Add fail-on-missing to actions/upload-artifact.
This ensures that the workflow fails if the release notes file is not created by Gemini, preventing release creation.