### PR TITLE
Improve the mismatched rpm versions across multi-arch images check

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_rpm_packages.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_rpm_packages.adoc
@@ -11,10 +11,10 @@ Rules used to verify different properties of specific RPM packages found in the 
 [#rpm_packages__unique_version]
 === link:#rpm_packages__unique_version[Unique Version]
 
-Check if there is more than one version of the same RPM installed across different architectures. This check only applies for Image Indexes, aka multi-platform images. Use the `non_unique_rpm_names` rule data key to ignore certain RPMs.
+Check if a multi-arch build has the same RPM versions installed across each different architecture. This check only applies for Image Indexes, aka multi-platform images. Use the `non_unique_rpm_names` rule data key to ignore certain RPMs.
 
 * Rule type: [rule-type-indicator failure]#FAILURE#
-* FAILURE message: `Multiple versions of the %q RPM were found: %s`
+* FAILURE message: `Mismatched versions of the %q RPM were found across different arches. %s`
 * Code: `rpm_packages.unique_version`
 * Effective from: `2025-10-01T00:00:00Z`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_packages/rpm_packages.rego#L17[Source, window="_blank"]

--- a/antora/docs/modules/ROOT/pages/packages/release_rpm_packages.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_rpm_packages.adoc
@@ -16,5 +16,4 @@ Check if a multi-arch build has the same RPM versions installed across each diff
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Mismatched versions of the %q RPM were found across different arches. %s`
 * Code: `rpm_packages.unique_version`
-* Effective from: `2025-10-01T00:00:00Z`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/rpm_packages/rpm_packages.rego#L17[Source, window="_blank"]

--- a/policy/lib/string_utils.rego
+++ b/policy/lib/string_utils.rego
@@ -10,3 +10,12 @@ quoted_values_string(value_list) := result if {
 
 	result := concat(", ", quoted_list)
 }
+
+pluralize_maybe(set_or_list, singular_word, plural_word) := singular_word if {
+	# One item, use the singular word
+	count(set_or_list) == 1
+} else := sprintf("%ss", [singular_word]) if {
+	# No plural word provided, make one by adding an "s"
+	plural_word in {null, ""}
+	# Use provided plural word
+} else := plural_word

--- a/policy/lib/string_utils_test.rego
+++ b/policy/lib/string_utils_test.rego
@@ -8,3 +8,23 @@ test_quoted_values_string if {
 	lib.assert_equal("'a', 'b', 'c'", lib.quoted_values_string(["a", "b", "c"]))
 	lib.assert_equal("'a', 'b', 'c'", lib.quoted_values_string({"a", "b", "c"}))
 }
+
+test_pluralize_maybe if {
+	test_cases := [
+		{
+			"singular": "mouse",
+			"plural": "mice",
+			"expected": ["mouse", "mice", "mice"],
+		},
+		{
+			"singular": "bug",
+			"plural": "",
+			"expected": ["bug", "bugs", "bugs"],
+		},
+	]
+
+	every t in test_cases {
+		result := [lib.pluralize_maybe(s, t.singular, t.plural) | some s in [{"a"}, {"a", "b"}, {}]]
+		lib.assert_equal(t.expected, result)
+	}
+}

--- a/policy/release/rpm_packages/rpm_packages.rego
+++ b/policy/release/rpm_packages/rpm_packages.rego
@@ -31,11 +31,6 @@ import data.lib.tekton
 deny contains result if {
 	image.is_image_index(input.image.ref)
 
-	# Arguably this is a weird edge case that should be dealt with by changing
-	# the build to not be multi-arch. But this avoids producing a confusing and
-	# not useful violation in some cases.
-	not _is_single_image_index(input.image.ref)
-
 	some rpm_name in rpm_names_with_mismatched_nvr_sets
 	not rpm_name in lib.rule_data("non_unique_rpm_names")
 
@@ -128,10 +123,3 @@ all_rpms_by_name_and_platform[rpm_name][platform] contains nvr if {
 	# RPM terms, hence this is the name-version-release, aka the nvr
 	nvr := sprintf("%s-%s", [rpm_name, rpm_version])
 }
-
-# For detecting image indexes with just a single image in them.
-# (I don't think there are any valid reasons for these to exist)
-_is_single_image_index(ref) if {
-	index := ec.oci.image_index(ref)
-	count(index.manifests) == 1
-} else := false

--- a/policy/release/rpm_packages/rpm_packages.rego
+++ b/policy/release/rpm_packages/rpm_packages.rego
@@ -25,8 +25,6 @@ import data.lib.tekton
 #   failure_msg: 'Mismatched versions of the %q RPM were found across different arches. %s'
 #   collections:
 #   - redhat
-#   # Pushed back again due to https://issues.redhat.com/browse/EC-1354
-#   effective_on: 2025-10-01T00:00:00Z
 #
 deny contains result if {
 	image.is_image_index(input.image.ref)

--- a/policy/release/rpm_packages/rpm_packages.rego
+++ b/policy/release/rpm_packages/rpm_packages.rego
@@ -17,12 +17,12 @@ import data.lib.tekton
 # METADATA
 # title: Unique Version
 # description: >-
-#   Check if there is more than one version of the same RPM installed across different
-#   architectures. This check only applies for Image Indexes, aka multi-platform images.
+#   Check if a multi-arch build has the same RPM versions installed across each different
+#   architecture. This check only applies for Image Indexes, aka multi-platform images.
 #   Use the `non_unique_rpm_names` rule data key to ignore certain RPMs.
 # custom:
 #   short_name: unique_version
-#   failure_msg: 'Multiple versions of the %q RPM were found: %s'
+#   failure_msg: 'Mismatched versions of the %q RPM were found across different arches. %s'
 #   collections:
 #   - redhat
 #   # Pushed back again due to https://issues.redhat.com/browse/EC-1354
@@ -36,40 +36,97 @@ deny contains result if {
 	# not useful violation in some cases.
 	not _is_single_image_index(input.image.ref)
 
-	some name, versions in grouped_rpm_purls
-	count(versions) > 1
-	not name in lib.rule_data("non_unique_rpm_names")
+	some rpm_name in rpm_names_with_mismatched_nvr_sets
+	not rpm_name in lib.rule_data("non_unique_rpm_names")
+
+	detail_text := concat(" ", sort(rpm_mismatch_details(rpm_name)))
+
 	result := lib.result_helper_with_term(
 		rego.metadata.chain(),
-		[name, concat(", ", versions)],
-		name,
+		[rpm_name, detail_text],
+		rpm_name,
 	)
 }
 
-# grouped_rpm_purls groups the found RPMs by name to facilitate detecting different versions. It
-# has the following structure:
-# {
-#     "spam-maps": {"1.2.3-0", "1.2.3-9"},
-#     "bacon": {"7.8.8-8"},
-# }
-grouped_rpm_purls[name] contains version if {
-	some rpm_purl in all_rpm_purls
-	rpm := ec.purl.parse(rpm_purl)
-	name := rpm.name
+# Do some extra work here to make a nice tidy violation message
+rpm_mismatch_details(rpm_name) := [detail |
+	# Get all unique NVR sets for this RPM
+	some nvr_set in {nvrs |
+		some platform, nvrs in all_rpms_by_name_and_platform[rpm_name]
+	}
 
-	# NOTE: This includes both version and release.
-	version := rpm.version
+	# Find all platforms that have this NVR set
+	platforms_with_nvr_set := [platform |
+		some platform, nvrs in all_rpms_by_name_and_platform[rpm_name]
+		nvrs == nvr_set
+	]
+
+	detail := sprintf("%s %s %s %s.", [
+		lib.pluralize_maybe(platforms_with_nvr_set, "Platform", ""),
+		concat(", ", sort(platforms_with_nvr_set)),
+		lib.pluralize_maybe(platforms_with_nvr_set, "has", "have"),
+		concat(", ", sort(nvr_set)),
+	])
+]
+
+# Detect RPMs where the set of nvrs differs across platforms.
+# Generally the sets of versions are of size one, but in some cases we have more
+# than one version of a particular rpm due to multi-stage builds.
+rpm_names_with_mismatched_nvr_sets contains rpm_name if {
+	some rpm_name, platform_sets in all_rpms_by_name_and_platform
+	nvr_sets := {nvrs | some _platform, nvrs in platform_sets}
+
+	# If there are more than one unique set of nvrs, then we have some
+	# kind of mismatch between the platforms
+	count(nvr_sets) > 1
 }
 
-all_rpm_purls contains rpm.purl if {
+# A list of rpms grouped by rpm name and by platform
+# Something like this:
+# {
+#   "acl": {
+#     "linux/arm64": ["acl-2.3.1-4.el9"],
+#     "linux/ppc64le": ["acl-2.3.1-4.el9"],
+#     ...
+#   },
+#   ...
+# }
+all_rpms_by_name_and_platform[rpm_name][platform] contains nvr if {
 	some attestation in lib.pipelinerun_attestations
+
+	# We're expecting multiple matrixed build tasks, one
+	# for each platform
 	some build_task in tekton.build_tasks(attestation)
+
+	# Determine which os/arch was built by this build task.
+	# Note: We expect this to be present for the Konflux multi-arch builds. If it
+	# isn't then this check doesn't work and mismatched rpm versions will not be
+	# detected. If there was somehow a different way to build a multi-arch image,
+	# we would need to find another way to figure out which platform each SBOM is
+	# related to.
+	platform := tekton.task_param(build_task, "PLATFORM")
+
+	# Find the SBOM location
 	some result in tekton.task_results(build_task)
 	result.name == "SBOM_BLOB_URL"
-	url := result.value
-	blob := ec.oci.blob(url)
-	s := json.unmarshal(blob)
-	some rpm in sbom.rpms_from_sbom(s)
+	sbom_blob_ref := result.value
+
+	# Fetch the SBOM data
+	sbom_blob := ec.oci.blob(sbom_blob_ref)
+	s := json.unmarshal(sbom_blob)
+
+	# Extract the list of rpm purls from the SBOM and parse out
+	# the rpm version details
+	some rpm_info in sbom.rpms_from_sbom(s)
+	rpm := ec.purl.parse(rpm_info.purl)
+	rpm_name := rpm.name
+	rpm_version := rpm.version
+
+	# We really only need the version, but it's convenient for
+	# creating violation messages if we use the full nvr here.
+	# Note that rpm.version is actually the version and the release in
+	# RPM terms, hence this is the name-version-release, aka the nvr
+	nvr := sprintf("%s-%s", [rpm_name, rpm_version])
 }
 
 # For detecting image indexes with just a single image in them.

--- a/policy/release/rpm_packages/rpm_packages_test.rego
+++ b/policy/release/rpm_packages/rpm_packages_test.rego
@@ -32,7 +32,10 @@ test_failure_cyclonedx if {
 
 	expected := {{
 		"code": "rpm_packages.unique_version",
-		"msg": "Multiple versions of the \"spam\" RPM were found: 1.0.0-1, 1.0.0-2",
+		"msg": sprintf("%s %s", [
+			"Mismatched versions of the \"spam\" RPM were found across different arches.",
+			"Platform linux/amd64 has spam-1.0.0-1. Platform linux/arm64 has spam-1.0.0-2.",
+		]),
 		"term": "spam",
 	}}
 
@@ -48,7 +51,10 @@ test_failure_spdx if {
 
 	expected := {{
 		"code": "rpm_packages.unique_version",
-		"msg": "Multiple versions of the \"spam\" RPM were found: 1.0.0-1, 1.0.0-2",
+		"msg": sprintf("%s %s", [
+			"Mismatched versions of the \"spam\" RPM were found across different arches.",
+			"Platform linux/amd64 has spam-1.0.0-1. Platform linux/arm64 has spam-1.0.0-2.",
+		]),
 		"term": "spam",
 	}}
 
@@ -94,7 +100,10 @@ test_multi_image_index if {
 
 	expected := {{
 		"code": "rpm_packages.unique_version",
-		"msg": "Multiple versions of the \"spam\" RPM were found: 1.0.0-1, 1.0.0-2",
+		"msg": sprintf("%s %s", [
+			"Mismatched versions of the \"spam\" RPM were found across different arches.",
+			"Platform linux/amd64 has spam-1.0.0-1. Platform linux/arm64 has spam-1.0.0-2.",
+		]),
 		"term": "spam",
 	}}
 
@@ -103,6 +112,54 @@ test_multi_image_index if {
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
 		with ec.oci.blob as _mock_blob
 		with ec.oci.image_index as _mock_image_index
+}
+
+test_success_multiple_versions_same_across_platforms if {
+	# Both platforms have the same set of multiple spam versions - should NOT trigger violation
+	att := _attestation_with_sboms([_multi_spam_url, _multi_spam_url])
+
+	lib.assert_empty(rpm_packages.deny) with input.attestations as [att]
+		with input.image.ref as "registry.local/image-index@sha256:image_index_digest"
+		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
+		with ec.oci.blob as _mock_blob
+}
+
+test_failure_multiple_versions_different_across_platforms if {
+	# One platform has multiple spam versions, another has single - should trigger violation
+	att := _attestation_with_sboms([_multi_spam_url, _single_spam_url])
+
+	expected := {{
+		"code": "rpm_packages.unique_version",
+		"msg": sprintf("%s %s", [
+			"Mismatched versions of the \"spam\" RPM were found across different arches.",
+			"Platform linux/amd64 has spam-1.0.0-1, spam-1.0.0-2. Platform linux/arm64 has spam-1.0.0-1.",
+		]),
+		"term": "spam",
+	}}
+
+	lib.assert_equal_results(expected, rpm_packages.deny) with input.attestations as [att]
+		with input.image.ref as "registry.local/image-index@sha256:image_index_digest"
+		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
+		with ec.oci.blob as _mock_blob
+}
+
+test_failure_with_platform_grouping if {
+	# Three platforms have spam-1.0.0-1, one platform has spam-1.0.0-3 - should trigger violation with grouping
+	att := _attestation_with_sboms([_single_spam_url, _single_spam_url, _single_spam_url, _spam_v3_url])
+
+	expected := {{
+		"code": "rpm_packages.unique_version",
+		"msg": sprintf("%s %s", [
+			"Mismatched versions of the \"spam\" RPM were found across different arches.",
+			"Platform linux/s390x has spam-1.0.0-3. Platforms linux/amd64, linux/arm64, linux/ppc64le have spam-1.0.0-1.",
+		]),
+		"term": "spam",
+	}}
+
+	lib.assert_equal_results(expected, rpm_packages.deny) with input.attestations as [att]
+		with input.image.ref as "registry.local/image-index@sha256:image_index_digest"
+		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
+		with ec.oci.blob as _mock_blob
 }
 
 _mock_blob(`"registry.local/cyclonedx-1@sha256:cyclonedx-1-digest"`) := json.marshal({"components": [
@@ -155,6 +212,53 @@ _mock_blob(`"registry.local/spdx-2@sha256:spdx-2-digest"`) := json.marshal({"pac
 	}]},
 ]})
 
+# Mock blob with multiple versions of spam (both 1.0.0-1 and 1.0.0-2)
+_mock_blob(`"registry.local/multi-spam@sha256:multi-spam-digest"`) := json.marshal({"packages": [
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE_MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/spam@1.0.0-1",
+	}]},
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE_MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/spam@1.0.0-2",
+	}]},
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE_MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/bacon@1.0.0-2",
+	}]},
+]})
+
+# Mock blob with only one version of spam (1.0.0-1) - for mismatch testing
+_mock_blob(`"registry.local/single-spam@sha256:single-spam-digest"`) := json.marshal({"packages": [
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE_MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/spam@1.0.0-1",
+	}]},
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE_MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/bacon@1.0.0-2",
+	}]},
+]})
+
+# Mock blob with spam version 1.0.0-3 - for grouping test
+_mock_blob(`"registry.local/spam-v3@sha256:spam-v3-digest"`) := json.marshal({"packages": [
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE_MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/spam@1.0.0-3",
+	}]},
+	{"externalRefs": [{
+		"referenceType": "purl",
+		"referenceCategory": "PACKAGE_MANAGER",
+		"referenceLocator": "pkg:rpm/redhat/bacon@1.0.0-2",
+	}]},
+]})
+
 _cyclonedx_url_1 := "registry.local/cyclonedx-1@sha256:cyclonedx-1-digest"
 
 _cyclonedx_url_2 := "registry.local/cyclonedx-2@sha256:cyclonedx-2-digest"
@@ -163,9 +267,17 @@ _spdx_url_1 := "registry.local/spdx-1@sha256:spdx-1-digest"
 
 _spdx_url_2 := "registry.local/spdx-2@sha256:spdx-2-digest"
 
+_multi_spam_url := "registry.local/multi-spam@sha256:multi-spam-digest"
+
+_single_spam_url := "registry.local/single-spam@sha256:single-spam-digest"
+
+_spam_v3_url := "registry.local/spam-v3@sha256:spam-v3-digest"
+
 _attestation_with_sboms(sbom_urls) := attestation if {
+	platforms := ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 	tasks := [task |
 		some i, url in sbom_urls
+		platform := platforms[i % count(platforms)]
 		task_with_result := tekton_test.slsav1_task_result_ref(
 			sprintf("some-build-%d", [i]),
 			[
@@ -181,7 +293,15 @@ _attestation_with_sboms(sbom_urls) := attestation if {
 				},
 			],
 		)
-		task := tekton_test.slsav1_task_bundle(task_with_result, _bundle)
+		task_with_bundle := tekton_test.slsav1_task_bundle(task_with_result, _bundle)
+		task := json.patch(task_with_bundle, [{
+			"op": "add",
+			"path": "/spec/params/-",
+			"value": {
+				"name": "PLATFORM",
+				"value": platform,
+			},
+		}])
 	]
 
 	attestation := lib_test.mock_slsav1_attestation_with_tasks(tasks)

--- a/policy/release/rpm_packages/rpm_packages_test.rego
+++ b/policy/release/rpm_packages/rpm_packages_test.rego
@@ -14,7 +14,6 @@ test_success_cyclonedx if {
 		with input.image.ref as "registry.local/image-index@sha256:image_index_digest"
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
 		with ec.oci.blob as _mock_blob
-		with ec.oci.image_index as _mock_image_index
 }
 
 test_success_spdx if {
@@ -24,7 +23,6 @@ test_success_spdx if {
 		with input.image.ref as "registry.local/image-index@sha256:image_index_digest"
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
 		with ec.oci.blob as _mock_blob
-		with ec.oci.image_index as _mock_image_index
 }
 
 test_failure_cyclonedx if {
@@ -43,7 +41,6 @@ test_failure_cyclonedx if {
 		with input.image.ref as "registry.local/image-index@sha256:image_index_digest"
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
 		with ec.oci.blob as _mock_blob
-		with ec.oci.image_index as _mock_image_index
 }
 
 test_failure_spdx if {
@@ -62,7 +59,6 @@ test_failure_spdx if {
 		with input.image.ref as "registry.local/image-index@sha256:image-index-digest"
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
 		with ec.oci.blob as _mock_blob
-		with ec.oci.image_index as _mock_image_index
 }
 
 test_non_image_index if {
@@ -82,36 +78,6 @@ test_ignore_names if {
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
 		with ec.oci.blob as _mock_blob
 		with data.rule_data.non_unique_rpm_names as ["spam"]
-		with ec.oci.image_index as _mock_image_index
-}
-
-test_single_image_index if {
-	att := _attestation_with_sboms([_spdx_url_1, _spdx_url_2])
-
-	lib.assert_empty(rpm_packages.deny) with input.attestations as [att]
-		with input.image.ref as "registry.local/image-index@sha256:single-image-index"
-		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
-		with ec.oci.blob as _mock_blob
-		with ec.oci.image_index as _mock_image_index
-}
-
-test_multi_image_index if {
-	att := _attestation_with_sboms([_spdx_url_1, _spdx_url_2])
-
-	expected := {{
-		"code": "rpm_packages.unique_version",
-		"msg": sprintf("%s %s", [
-			"Mismatched versions of the \"spam\" RPM were found across different arches.",
-			"Platform linux/amd64 has spam-1.0.0-1. Platform linux/arm64 has spam-1.0.0-2.",
-		]),
-		"term": "spam",
-	}}
-
-	lib.assert_equal_results(expected, rpm_packages.deny) with input.attestations as [att]
-		with input.image.ref as "registry.local/image-index@sha256:multi-image-index"
-		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.index.v1+json"}
-		with ec.oci.blob as _mock_blob
-		with ec.oci.image_index as _mock_image_index
 }
 
 test_success_multiple_versions_same_across_platforms if {
@@ -308,32 +274,3 @@ _attestation_with_sboms(sbom_urls) := attestation if {
 }
 
 _bundle := "registry.img/spam@sha256:4e388ab32b10dc8dbc7e28144f552830adc74787c1e2c0824032078a79f227fb"
-
-# Mock image index responses
-_mock_image_index("registry.local/image-index@sha256:single-image-index") := {"manifests": [{
-	"mediaType": "application/vnd.oci.image.manifest.v1+json",
-	"digest": "sha256:abc123",
-	"platform": {
-		"architecture": "amd64",
-		"os": "linux",
-	},
-}]}
-
-_mock_image_index("registry.local/image-index@sha256:multi-image-index") := {"manifests": [
-	{
-		"mediaType": "application/vnd.oci.image.manifest.v1+json",
-		"digest": "sha256:abc123",
-		"platform": {
-			"architecture": "amd64",
-			"os": "linux",
-		},
-	},
-	{
-		"mediaType": "application/vnd.oci.image.manifest.v1+json",
-		"digest": "sha256:def456",
-		"platform": {
-			"architecture": "arm64",
-			"os": "linux",
-		},
-	},
-]}


### PR DESCRIPTION
Avoid unwanted violations when there are more than one version of the same rpm in an images SBOM.

See longer explanations in the commit messages.

Ref: https://issues.redhat.com/browse/EC-1354