### PR TITLE
fix: Extend a OCI reference regex to support generic hostname

### DIFF
--- a/policy/lib/image/image.rego
+++ b/policy/lib/image/image.rego
@@ -8,9 +8,10 @@ parse(ref) := d if {
 	trimmed_ref := trim_space(ref)
 
 	# Note: This regex is simplified and does not cover all valid hostname cases.
-	# It only matches hostnames in the form of registry.local' or 'Registry1.io'.
+	# It only matches hostnames in the form of <hostname><optional port><optional path>.
+	# For example "registry.com", "registry.com/repo", "localhost:5000/repo/subrepo"
 	# It does not include all subdomains and does not support Unicode.
-	regex.match(`^(?:[a-zA-Z0-9-])+\.[a-zA-Z]+`, trimmed_ref)
+	regex.match(`^([A-Za-z0-9.-]+(?::[0-9]+)?)(?:\/.*)?$`, trimmed_ref)
 
 	# a valid repo will contain a /
 	contains(trimmed_ref, "/")

--- a/policy/lib/image/image_test.rego
+++ b/policy/lib/image/image_test.rego
@@ -9,6 +9,7 @@ import data.lib.image
 test_parse if {
 	repository := "registry.com/re/po"
 	repository_with_port := "registry.com:8443/re/po"
+	local_repository := "localhost:9000/re/po"
 	tag := "latest"
 	digest := "sha256:01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"
 
@@ -45,6 +46,10 @@ test_parse if {
 	lib.assert_equal(
 		image.parse(concat("", [repository_with_port, ":", tag, " "])),
 		{"repo": repository_with_port, "tag": tag, "digest": ""},
+	)
+	lib.assert_equal(
+		image.parse(concat("", [local_repository, ":", tag, "@", digest])),
+		{"repo": local_repository, "tag": tag, "digest": digest},
 	)
 }
 


### PR DESCRIPTION
The old regex only supported a hostname that always contained a "." character. This however exclude valid hostnames like "localhost".

This change updates a regex to support hostname, optional port and path.

This issue was discovered while integrating Conforma checks into SBOM generator test suite to make sure generators are inline with Conforma rules.

JIRA: ISV-6206