### PR TITLE
Allow PNC SLSA build type for PipelineRun attestations

### DIFF
--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -454,6 +454,39 @@ _attestation_v1_with_finished_on(finished_on, tasks) := {"statement": {
 	},
 }}
 
+# Test PNC SLSA v1 attestation with a non-Tekton buildType.
+_attestation_v1_with_pnc_build_type := {"statement": {
+	"predicateType": "https://slsa.dev/provenance/v1",
+	"predicate": {
+		"buildDefinition": {
+			"buildType": "https://project-ncl.github.io/slsa-pnc-cli-buildtypes/workflow/v1",
+			"externalParameters": {
+				"commandLine": [],
+				"fullVersion": "1.0",
+				"pigConfiguration": {},
+				"prefix": "",
+				"releaseDirName": "",
+				"targetPath": "",
+				"tempBuild": false,
+			},
+			"resolvedDependencies": _mock_materials,
+		},
+		"runDetails": {
+			"builder": {},
+			"metadata": {"finishedOn": "2025-01-20T15:45:00Z"},
+		},
+	},
+}}
+
+test_pipelinerun_attestations_pnc_build_type if {
+	att := _attestation_v1_with_pnc_build_type
+	expected := [att]
+	assertions.assert_equal(
+		expected,
+		lib.pipelinerun_attestations,
+	) with input.attestations as [att] with data.rule_data__configuration__ as {"allowed_provenance_build_types": ["https://project-ncl.github.io/slsa-pnc-cli-buildtypes/workflow/v1"]}
+}
+
 test_pipelinerun_attestations_single_v1_finished_on if {
 	# Single v1.0 attestation using spec-compliant finishedOn - should be returned
 	att := _attestation_v1_with_finished_on("2025-01-20T15:45:00Z", [_build_task])


### PR DESCRIPTION
#### What:
<!--- What is this change doing? --->

The goal of this change is to make Conforma work with the PNC SLSA v1 attestation build type.

This is a targeted compatibility change. It allows the PNC build type to be recognized as a PipelineRun attestation and adds a regression test for this specific attestation format.

This change does not make all rules defined in this repository automatically work with the PNC attestation. Additional rules may require separate future work, either in this repository or through custom Enterprise Contract definitions, where applicable.

- Added the PNC SLSA v1 build type to the allowed provenance build types.
- Added a regression test for the PNC SLSA v1 attestation.

#### Why:
<!--- Please include the context and background for your change. --->

PNC produces an SLSA v1 attestation using the PNC-specific build type:

`https://project-ncl.github.io/slsa-pnc-cli-buildtypes/workflow/v1`

The change is needed so that Conforma recognizes this attestation as a supported PipelineRun attestation.

The existing `attestation_type.known_attestation_type` rule already recognizes the PNC attestation's `_type`, so this change does not modify that rule.

## Testing

- PNC-specific regression test: PASS
- `attestation_type.known_attestation_type`: PASS
- Full policy suite: 1070/1071 tests pass.
- The remaining `lib.json_test.test_validate_args` failure is also present on the clean baseline and is unrelated to this change.

#### Tickets:
<!--- Please link to any related Jira issue here. --->
MMENG-4662
