### PR TITLE
Allow PNC SLSA build type for PipelineRun attestations

### DIFF
--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -454,6 +454,39 @@ _attestation_v1_with_finished_on(finished_on, tasks) := {"statement": {
 	},
 }}
 
+# Test PNC SLSA v1 attestation with a non-Tekton buildType.
+_attestation_v1_with_pnc_build_type := {"statement": {
+	"predicateType": "https://slsa.dev/provenance/v1",
+	"predicate": {
+		"buildDefinition": {
+			"buildType": "https://project-ncl.github.io/slsa-pnc-cli-buildtypes/workflow/v1",
+			"externalParameters": {
+				"commandLine": [],
+				"fullVersion": "1.0",
+				"pigConfiguration": {},
+				"prefix": "",
+				"releaseDirName": "",
+				"targetPath": "",
+				"tempBuild": false,
+			},
+			"resolvedDependencies": _mock_materials,
+		},
+		"runDetails": {
+			"builder": {},
+			"metadata": {"finishedOn": "2025-01-20T15:45:00Z"},
+		},
+	},
+}}
+
+test_pipelinerun_attestations_pnc_build_type if {
+	att := _attestation_v1_with_pnc_build_type
+	expected := [att]
+	assertions.assert_equal(
+		expected,
+		lib.pipelinerun_attestations,
+	) with input.attestations as [att] with data.rule_data__configuration__ as {"allowed_provenance_build_types": ["https://project-ncl.github.io/slsa-pnc-cli-buildtypes/workflow/v1"]}
+}
+
 test_pipelinerun_attestations_single_v1_finished_on if {
 	# Single v1.0 attestation using spec-compliant finishedOn - should be returned
 	att := _attestation_v1_with_finished_on("2025-01-20T15:45:00Z", [_build_task])


### PR DESCRIPTION
### What:

Add a regression test showing that the PNC SLSA v1 build type can be accepted for PipelineRun attestations when it is explicitly provided through `rule_data`.

The PNC build type is not added to Conforma's global/default provenance allowlist.

### Why:

PNC produces SLSA v1 attestations with a PNC-specific `buildType`. The goal is to verify that Conforma can accept this build type through custom `rule_data`, without enabling it globally for all Conforma users.

### Testing:

* PNC-specific regression test passes.
* Full Conforma test suite: 1071/1071 tests passed.
* `make fmt-check` passes.
* `git diff --check` passes.

### Related:

This follows the suggestion to use custom `rule_data` to enable the PNC build type instead of modifying the default provenance allowlist.
