### PR TITLE
EC-2026: Verify SBOM attestations with signing identities

### DIFF
--- a/acceptance/features/sbom_proxy.feature
+++ b/acceptance/features/sbom_proxy.feature
@@ -9,7 +9,8 @@ Feature: SBOM proxy rules
                     {
                         "policy": [
                             "$GITROOT/policy/lib",
-                            "$GITROOT/policy/release"
+                            "$GITROOT/policy/release",
+                            "$GITROOT/acceptance/policy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"
@@ -38,7 +39,8 @@ Feature: SBOM proxy rules
                     {
                         "policy": [
                             "$GITROOT/policy/lib",
-                            "$GITROOT/policy/release"
+                            "$GITROOT/policy/release",
+                            "$GITROOT/acceptance/policy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules-npm-only"
@@ -65,7 +67,8 @@ Feature: SBOM proxy rules
                     {
                         "policy": [
                             "$GITROOT/policy/lib",
-                            "$GITROOT/policy/release"
+                            "$GITROOT/policy/release",
+                            "$GITROOT/acceptance/policy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"
@@ -94,7 +97,8 @@ Feature: SBOM proxy rules
                     {
                         "policy": [
                             "$GITROOT/policy/lib",
-                            "$GITROOT/policy/release"
+                            "$GITROOT/policy/release",
+                            "$GITROOT/acceptance/policy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"
@@ -122,7 +126,8 @@ Feature: SBOM proxy rules
                     {
                         "policy": [
                             "$GITROOT/policy/lib",
-                            "$GITROOT/policy/release"
+                            "$GITROOT/policy/release",
+                            "$GITROOT/acceptance/policy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"
@@ -151,7 +156,8 @@ Feature: SBOM proxy rules
                     {
                         "policy": [
                             "$GITROOT/policy/lib",
-                            "$GITROOT/policy/release"
+                            "$GITROOT/policy/release",
+                            "$GITROOT/acceptance/policy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules-npm-only"
@@ -178,7 +184,8 @@ Feature: SBOM proxy rules
                     {
                         "policy": [
                             "$GITROOT/policy/lib",
-                            "$GITROOT/policy/release"
+                            "$GITROOT/policy/release",
+                            "$GITROOT/acceptance/policy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"
@@ -207,7 +214,8 @@ Feature: SBOM proxy rules
                     {
                         "policy": [
                             "$GITROOT/policy/lib",
-                            "$GITROOT/policy/release"
+                            "$GITROOT/policy/release",
+                            "$GITROOT/acceptance/policy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"

--- a/acceptance/features/sbom_proxy.feature
+++ b/acceptance/features/sbom_proxy.feature
@@ -10,7 +10,7 @@ Feature: SBOM proxy rules
                         "policy": [
                             "$GITROOT/policy/lib",
                             "$GITROOT/policy/release",
-                            "$GITROOT/acceptance/policy"
+                            "$GITROOT/acceptance/policy/sbom_proxy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"
@@ -40,7 +40,7 @@ Feature: SBOM proxy rules
                         "policy": [
                             "$GITROOT/policy/lib",
                             "$GITROOT/policy/release",
-                            "$GITROOT/acceptance/policy"
+                            "$GITROOT/acceptance/policy/sbom_proxy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules-npm-only"
@@ -68,7 +68,7 @@ Feature: SBOM proxy rules
                         "policy": [
                             "$GITROOT/policy/lib",
                             "$GITROOT/policy/release",
-                            "$GITROOT/acceptance/policy"
+                            "$GITROOT/acceptance/policy/sbom_proxy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"
@@ -98,7 +98,7 @@ Feature: SBOM proxy rules
                         "policy": [
                             "$GITROOT/policy/lib",
                             "$GITROOT/policy/release",
-                            "$GITROOT/acceptance/policy"
+                            "$GITROOT/acceptance/policy/sbom_proxy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"
@@ -127,7 +127,7 @@ Feature: SBOM proxy rules
                         "policy": [
                             "$GITROOT/policy/lib",
                             "$GITROOT/policy/release",
-                            "$GITROOT/acceptance/policy"
+                            "$GITROOT/acceptance/policy/sbom_proxy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"
@@ -157,7 +157,7 @@ Feature: SBOM proxy rules
                         "policy": [
                             "$GITROOT/policy/lib",
                             "$GITROOT/policy/release",
-                            "$GITROOT/acceptance/policy"
+                            "$GITROOT/acceptance/policy/sbom_proxy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules-npm-only"
@@ -185,7 +185,7 @@ Feature: SBOM proxy rules
                         "policy": [
                             "$GITROOT/policy/lib",
                             "$GITROOT/policy/release",
-                            "$GITROOT/acceptance/policy"
+                            "$GITROOT/acceptance/policy/sbom_proxy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"
@@ -215,7 +215,7 @@ Feature: SBOM proxy rules
                         "policy": [
                             "$GITROOT/policy/lib",
                             "$GITROOT/policy/release",
-                            "$GITROOT/acceptance/policy"
+                            "$GITROOT/acceptance/policy/sbom_proxy"
                         ],
                         "data": [
                             "$GITROOT/acceptance/testdata/proxy-rules"

--- a/acceptance/policy/lib/sbom.rego
+++ b/acceptance/policy/lib/sbom.rego
@@ -1,0 +1,11 @@
+package lib.sbom
+
+import rego.v1
+
+# The SBOM proxy scenarios use static policy-input samples captured after CLI
+# validation. Those samples do not retain an image reference, so expose their
+# embedded SBOMs to the downstream proxy rules exercised by these scenarios.
+# Runtime signature verification is covered by policy/lib/sbom/sbom_test.rego.
+_verified_sbom_attestations contains attestation if {
+	some attestation in input.attestations
+}

--- a/acceptance/policy/sbom_proxy/lib/sbom_acceptance_shim.rego
+++ b/acceptance/policy/sbom_proxy/lib/sbom_acceptance_shim.rego
@@ -5,7 +5,8 @@ import rego.v1
 # The SBOM proxy scenarios use static policy-input samples captured after CLI
 # validation. Those samples do not retain an image reference, so expose their
 # embedded SBOMs to the downstream proxy rules exercised by these scenarios.
-# Runtime signature verification is covered by policy/lib/sbom/sbom_test.rego.
+# This shim is scoped to the sbom_proxy feature; runtime signature verification
+# is covered by policy/lib/sbom/sbom_test.rego.
 _verified_sbom_attestations contains attestation if {
 	some attestation in input.attestations
 }

--- a/antora/docs/modules/ROOT/pages/packages/release_sbom.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_sbom.adoc
@@ -35,7 +35,7 @@ Confirm an SBOM attestation exists.
 [#sbom__signature_verification]
 === link:#sbom__signature_verification[SBOM signature verification failed]
 
-Report when signature verification fails for SBOMs discovered via OCI referrers or image-tag refs. The SBOM is excluded (fail-closed), but the user should know why.
+Report when signature verification fails for attached SBOM attestations or SBOMs discovered via OCI referrers or image-tag refs. The SBOM is excluded (fail-closed), but the user should know why.
 
 *Solution*: Check that the SBOM was signed with the key or certificate configured in the "sbom" entry of the signing_identities rule data, or that the signing identity matches.
 

--- a/design/sigstore-verification.md
+++ b/design/sigstore-verification.md
@@ -71,7 +71,8 @@ each signing identity is self-contained.
 | `lib/intoto/trust.rego` | `object.get(verification, "success", false) == true` | Boolean pass/fail gate |
 | `base_image_registries.rego` | `object.get(info, "success", false) == true` | Boolean pass/fail gate |
 | `lib/oci/oci.rego` | `object.get(info, "errors", [])` per referrer, filtered by `errors == []` | Gate a set of OCI referrers/tag refs to the signature-verified subset (fail-closed) |
-| `lib/sbom/sbom.rego` | `some raw_error in result.errors` over the failures set | Surface why each discovered SBOM was excluded, as warnings |
+| `lib/sbom/sbom.rego` | `some attestation in verification.attestations` | Accept attached SBOM attestations verified with the named `sbom` identity |
+| `lib/sbom/sbom.rego` | `some raw_error in result.errors` over the failures set | Surface why each referrer/tag SBOM was excluded, as warnings |
 
 Prefer `object.get(info, "success", false) == true` for pass/fail checks.
 Use `some raw_error in info.errors` when you need to surface individual error

--- a/design/sigstore-verification.md
+++ b/design/sigstore-verification.md
@@ -77,3 +77,19 @@ each signing identity is self-contained.
 Prefer `object.get(info, "success", false) == true` for pass/fail checks.
 Use `some raw_error in info.errors` when you need to surface individual error
 messages to the user.
+
+## Attached SBOM trust boundary
+
+CycloneDX and SPDX attestations embedded in policy input are not trusted
+directly. When a named `sbom` signing identity is configured,
+`lib/sbom/sbom.rego` uses the input image reference to retrieve and verify its
+attached attestations, and only exposes SBOM predicates from a successful
+verification result. Without that identity, or when verification fails, those
+SBOMs are excluded (fail-closed).
+
+This intentionally narrows the previous behavior, which exposed SBOM predicates
+from `input.attestations` without policy-side signature verification. An
+input-only or offline `ec validate --file` evaluation therefore cannot surface
+an attached-attestation SBOM unless the same attestation is available from the
+referenced image and can be verified. PipelineRun-derived SBOM blobs are
+unaffected because they follow their existing digest-matching path.

--- a/example/data/rule_data.yml
+++ b/example/data/rule_data.yml
@@ -38,9 +38,10 @@ rule_data:
     rh-release:
       public_key: "k8s://openshift-pipelines/release-signing-key"
       ignore_rekor: true
-    # Add an "sbom" identity to gate SBOM discovery via OCI referrers and
-    # image-tag refs: SBOMs are only accepted when their signatures verify
-    # against it, and excluded (fail-closed) when it is absent. Left
+    # Add an "sbom" identity to verify attached SBOM attestations and gate
+    # SBOM discovery via OCI referrers and image-tag refs. SBOMs are only
+    # accepted when their signatures verify against it, and excluded
+    # (fail-closed) when it is absent. Left
     # unconfigured by default; uncomment and set to your signing key to
     # enable, for example:
     # sbom:

--- a/example/data/rule_data.yml
+++ b/example/data/rule_data.yml
@@ -38,10 +38,11 @@ rule_data:
     rh-release:
       public_key: "k8s://openshift-pipelines/release-signing-key"
       ignore_rekor: true
-    # Add an "sbom" identity to verify attached SBOM attestations and gate
-    # SBOM discovery via OCI referrers and image-tag refs. SBOMs are only
-    # accepted when their signatures verify against it, and excluded
-    # (fail-closed) when it is absent. Left
+    # An "sbom" identity is required to expose attached SBOM attestations and
+    # SBOMs discovered via OCI referrers or image-tag refs. Previously,
+    # attached attestations from policy input were exposed without this
+    # policy-side verification. SBOMs are now excluded (fail-closed) when the
+    # identity is absent or their signatures do not verify. Left
     # unconfigured by default; uncomment and set to your signing key to
     # enable, for example:
     # sbom:

--- a/policy/lib/sbom/sbom.rego
+++ b/policy/lib/sbom/sbom.rego
@@ -10,9 +10,18 @@ import data.lib.sigstore
 import data.lib.tekton
 import rego.v1
 
-# cyclonedx_sboms and spdx_sboms returns a list of SBOMs associated with the image being validated.
-# It will first try to find them as references in the SLSA Provenance attestation and as an SBOM
-# attestation.
+# SBOM discovery is additive: every supported source is checked, and all results
+# associated with the image being evaluated are returned. Sources fall into
+# three groups:
+#
+#   1. signed SBOM attestations attached to the image;
+#   2. SBOM blobs recorded by build tasks in a PipelineRun attestation; and
+#   3. signed artifacts attached to the image through OCI referrers or legacy
+#      tag-based references.
+#
+# Each discovered document is classified as CycloneDX or SPDX. The public rules
+# expose arrays for callers, while the private set rules deduplicate documents
+# found through more than one source.
 
 _sbom_artifact_types := {
 	"application/spdx+json",
@@ -25,14 +34,18 @@ cyclonedx_sboms := [s | some s in _cyclonedx_sboms]
 
 spdx_sboms := [s | some s in _spdx_sboms]
 
-# Private set rules for deduplication. Sets naturally eliminate duplicates when the
-# same SBOM is discovered via multiple methods (attestation, OCI blob, referrer, tag).
+# Build the result for each format in two stages. The *_without_image rules
+# collect SBOMs already present in attestations supplied to policy evaluation.
+# The *_from_image rules perform additional registry discovery for the image.
 _cyclonedx_sboms := _cyclonedx_sboms_without_image | _cyclonedx_sboms_from_image
 _cyclonedx_sboms_without_image := _cyclonedx_sboms_from_attestations | _cyclonedx_sboms_from_pipelinerun
 
 _spdx_sboms := _spdx_sboms_without_image | _spdx_sboms_from_image
 _spdx_sboms_without_image := _spdx_sboms_from_attestations | _spdx_sboms_from_pipelinerun
 
+# Signed SBOM attestations carry the SBOM directly as the in-toto predicate.
+# Verification is shared by both format-specific rules below; predicateType
+# determines which result set receives each document.
 _cyclonedx_sboms_from_attestations contains statement.predicate if {
 	some att in _verified_sbom_attestations
 	statement := att.statement
@@ -57,8 +70,9 @@ _spdx_sboms_from_attestations contains statement.predicate if {
 	statement.predicateType == "https://spdx.dev/Document"
 }
 
-# Attached SBOM attestations are verified against the named "sbom" signing
-# identity.
+# Verify attached SBOM attestations once, using the named "sbom" signing
+# identity, before either format-specific rule consumes them. With no configured
+# identity this set remains empty, so attached attestations are excluded.
 _verified_sbom_attestations contains attestation if {
 	_sbom_signing_identity_configured
 	verification := ec.sigstore.verify_attestation(input.image.ref, _sbom_signing_identity)
@@ -75,6 +89,11 @@ _spdx_sboms_from_image contains sbom if {
 	sbom.SPDXID == "SPDXRef-DOCUMENT"
 }
 
+# PipelineRun attestations are already part of the policy input. Their build
+# tasks point to external SBOM blobs through SBOM_BLOB_URL, so resolve each blob
+# after confirming that the task's IMAGE_DIGEST matches the evaluated image.
+# This digest check is what selects the correct platform SBOM when one
+# PipelineRun describes several platform images.
 _fetch_pipelinerun_sbom contains sbom if {
 	some attestation in lib.pipelinerun_attestations
 	some task in tekton.build_tasks(attestation)
@@ -89,13 +108,14 @@ _fetch_pipelinerun_sbom contains sbom if {
 	sbom := oci.parsed_blob(blob_ref)
 }
 
-# _fetch_sboms_from_image discovers SBOMs attached directly to the image being validated,
-# using the OCI Referrers API and legacy tag-based discovery.
+# Registry discovery supports both the current OCI Referrers API and the legacy
+# cosign tag convention. Both are evaluated and unioned; neither is a fallback
+# for the other. The set union also deduplicates a document exposed both ways.
 _fetch_sboms_from_image := _sboms_from_referrers | _sboms_from_tag_refs
 
-# Discover SBOMs via OCI Referrers API. Only referrers whose signatures
-# verify against the configured "sbom" signing identity are included. When
-# no such identity is configured, no referrer SBOMs are accepted (fail-closed).
+# OCI referrers advertise their content type in artifactType. Verify each
+# referrer first, keep only recognized SBOM media types, then parse its blob.
+# With no configured "sbom" signing identity, this source yields no SBOMs.
 _sboms_from_referrers contains sbom if {
 	_sbom_signing_identity_configured
 	some referrer in oci.verified_image_referrers(input.image.ref, _sbom_signing_identity)
@@ -103,9 +123,9 @@ _sboms_from_referrers contains sbom if {
 	sbom := oci.parsed_blob(referrer.ref)
 }
 
-# Discover SBOMs via legacy cosign tag-based conventions (.sbom suffix).
-# Only tag refs whose signatures verify against the configured "sbom" signing
-# identity are included (fail-closed when no such identity is configured).
+# Legacy discovery derives image tag references and identifies SBOM artifacts by
+# the .sbom suffix. As with referrers, only references verified with the named
+# "sbom" signing identity are parsed; without that identity this source is empty.
 _sboms_from_tag_refs contains sbom if {
 	_sbom_signing_identity_configured
 	some ref in oci.verified_image_tag_refs(input.image.ref, _sbom_signing_identity)

--- a/policy/lib/sbom/sbom.rego
+++ b/policy/lib/sbom/sbom.rego
@@ -76,6 +76,7 @@ _spdx_sboms_from_attestations contains statement.predicate if {
 _verified_sbom_attestations contains attestation if {
 	_sbom_signing_identity_configured
 	verification := ec.sigstore.verify_attestation(input.image.ref, _sbom_signing_identity)
+	object.get(verification, "success", false) == true
 	some attestation in verification.attestations
 }
 

--- a/policy/lib/sbom/sbom.rego
+++ b/policy/lib/sbom/sbom.rego
@@ -27,11 +27,14 @@ spdx_sboms := [s | some s in _spdx_sboms]
 
 # Private set rules for deduplication. Sets naturally eliminate duplicates when the
 # same SBOM is discovered via multiple methods (attestation, OCI blob, referrer, tag).
-_cyclonedx_sboms := (_cyclonedx_sboms_from_input | _cyclonedx_sboms_from_pipelinerun) | _cyclonedx_sboms_from_image
-_spdx_sboms := (_spdx_sboms_from_input | _spdx_sboms_from_pipelinerun) | _spdx_sboms_from_image
+_cyclonedx_sboms := _cyclonedx_sboms_without_image | _cyclonedx_sboms_from_image
+_cyclonedx_sboms_without_image := _cyclonedx_sboms_from_attestations | _cyclonedx_sboms_from_pipelinerun
 
-_cyclonedx_sboms_from_input contains statement.predicate if {
-	some att in input.attestations
+_spdx_sboms := _spdx_sboms_without_image | _spdx_sboms_from_image
+_spdx_sboms_without_image := _spdx_sboms_from_attestations | _spdx_sboms_from_pipelinerun
+
+_cyclonedx_sboms_from_attestations contains statement.predicate if {
+	some att in _verified_sbom_attestations
 	statement := att.statement
 
 	# https://cyclonedx.org/specification/overview/#recognized-predicate-type
@@ -48,10 +51,18 @@ _cyclonedx_sboms_from_image contains sbom if {
 	sbom.bomFormat == "CycloneDX"
 }
 
-_spdx_sboms_from_input contains statement.predicate if {
-	some att in input.attestations
+_spdx_sboms_from_attestations contains statement.predicate if {
+	some att in _verified_sbom_attestations
 	statement := att.statement
 	statement.predicateType == "https://spdx.dev/Document"
+}
+
+# Attached SBOM attestations are verified against the named "sbom" signing
+# identity.
+_verified_sbom_attestations contains attestation if {
+	_sbom_signing_identity_configured
+	verification := ec.sigstore.verify_attestation(input.image.ref, _sbom_signing_identity)
+	some attestation in verification.attestations
 }
 
 _spdx_sboms_from_pipelinerun contains sbom if {
@@ -86,6 +97,7 @@ _fetch_sboms_from_image := _sboms_from_referrers | _sboms_from_tag_refs
 # verify against the configured "sbom" signing identity are included. When
 # no such identity is configured, no referrer SBOMs are accepted (fail-closed).
 _sboms_from_referrers contains sbom if {
+	_sbom_signing_identity_configured
 	some referrer in oci.verified_image_referrers(input.image.ref, _sbom_signing_identity)
 	referrer.artifactType in _sbom_artifact_types
 	sbom := oci.parsed_blob(referrer.ref)
@@ -95,6 +107,7 @@ _sboms_from_referrers contains sbom if {
 # Only tag refs whose signatures verify against the configured "sbom" signing
 # identity are included (fail-closed when no such identity is configured).
 _sboms_from_tag_refs contains sbom if {
+	_sbom_signing_identity_configured
 	some ref in oci.verified_image_tag_refs(input.image.ref, _sbom_signing_identity)
 	endswith(ref, ".sbom")
 	sbom := oci.parsed_blob_from_image(ref)
@@ -514,14 +527,23 @@ rule_data_errors contains error if {
 _sbom_identity_name := "sbom"
 
 # _sbom_signing_identity is the named entry in the signing_identities rule
-# data used to verify SBOMs discovered via OCI referrers and image-tag refs.
-# It is undefined (fail-closed, silent) when no such identity is configured.
+# data used to verify SBOM attestations, OCI referrers, and image-tag refs.
+# Without a configured identity it defaults to an empty object; the configured
+# guard prevents verification and no SBOMs from those sources are accepted.
+default _sbom_signing_identity := {}
+
 _sbom_signing_identity := sigstore.named_identity(_sbom_identity_name)
+
+_sbom_signing_identity_configured if {
+	is_object(_sbom_signing_identity)
+	count(_sbom_signing_identity) > 0
+}
 
 # Collect SBOM signature verification errors for observability. Fail-closed
 # exclusion happens in the verified_* wrappers; this surfaces WHY an SBOM
 # was excluded, using the failures API to avoid duplicate builtin calls.
 signature_verification_errors contains error if {
+	_sbom_signing_identity_configured
 	some result in oci.image_referrer_failures(input.image.ref, _sbom_signing_identity)
 	result.item.artifactType in _sbom_artifact_types
 	some raw_error in result.errors
@@ -529,6 +551,7 @@ signature_verification_errors contains error if {
 }
 
 signature_verification_errors contains error if {
+	_sbom_signing_identity_configured
 	some result in oci.image_tag_ref_failures(input.image.ref, _sbom_signing_identity)
 	endswith(result.item, ".sbom")
 	some raw_error in result.errors

--- a/policy/lib/sbom/sbom.rego
+++ b/policy/lib/sbom/sbom.rego
@@ -565,6 +565,14 @@ _sbom_signing_identity_configured if {
 # was excluded, using the failures API to avoid duplicate builtin calls.
 signature_verification_errors contains error if {
 	_sbom_signing_identity_configured
+	verification := ec.sigstore.verify_attestation(input.image.ref, _sbom_signing_identity)
+	object.get(verification, "success", false) == false
+	some raw_error in verification.errors
+	error := sprintf("SBOM attestation signature verification failed for %s: %s", [input.image.ref, raw_error])
+}
+
+signature_verification_errors contains error if {
+	_sbom_signing_identity_configured
 	some result in oci.image_referrer_failures(input.image.ref, _sbom_signing_identity)
 	result.item.artifactType in _sbom_artifact_types
 	some raw_error in result.errors

--- a/policy/lib/sbom/sbom_test.rego
+++ b/policy/lib/sbom/sbom_test.rego
@@ -680,6 +680,18 @@ test_attestation_sbom_signature_verification_failure if {
 		with data.rule_data__configuration__ as {"signing_identities": {"sbom": _mock_sbom_opts}}
 }
 
+# A mixed verification result can retain successfully parsed attestations while
+# reporting failure for another attestation. Reject the entire result so partial
+# verification cannot admit an SBOM.
+test_attestation_sbom_partial_verification_failure if {
+	assertions.assert_empty(sbom.cyclonedx_sboms) with input.attestations as []
+		with input.image as _cyclonedx_image
+		with ec.sigstore.verify_attestation as _mock_verify_attestation_partial_failure
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data__configuration__ as {"signing_identities": {"sbom": _mock_sbom_opts}}
+}
+
 # The digest-pinned SBOM_BLOB_URL in verified provenance remains trusted and
 # does not require the "sbom" signing identity.
 test_pipelinerun_sbom_unaffected_by_sbom_opts if {
@@ -892,6 +904,15 @@ _mock_verify_attestation_failure(_, _) := {
 	"success": false,
 	"errors": ["verification failed"],
 	"attestations": [],
+}
+
+_mock_verify_attestation_partial_failure(_, _) := {
+	"success": false,
+	"errors": ["parsing another attestation failed"],
+	"attestations": [{"statement": {
+		"predicateType": "https://cyclonedx.org/bom",
+		"predicate": "partially verified sbom",
+	}}],
 }
 
 _mock_verify_image_success(_, _) := {"errors": []}

--- a/policy/lib/sbom/sbom_test.rego
+++ b/policy/lib/sbom/sbom_test.rego
@@ -50,10 +50,12 @@ test_cyclonedx_sboms if {
 	expected := ["sbom from attestation", {"sbom": "from oci blob", "bomFormat": "CycloneDX"}]
 	assertions.assert_equal(sbom.cyclonedx_sboms, expected) with input.attestations as attestations
 		with input.image as _cyclonedx_image
+		with ec.sigstore.verify_attestation as _mock_verify_cyclonedx_attestation
 		with ec.oci.blob as mock_ec_oci_cyclonedx_blob
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
+		with data.rule_data__configuration__ as {"signing_identities": {"sbom": _mock_sbom_opts}}
 }
 
 # test from attestation and fallback to oci image
@@ -94,10 +96,12 @@ test_spdx_sboms if {
 	expected := ["sbom from attestation", {"sbom": "from oci blob", "SPDXID": "SPDXRef-DOCUMENT"}]
 	assertions.assert_equal(sbom.spdx_sboms, expected) with input.attestations as attestations
 		with input.image as _spdx_image
+		with ec.sigstore.verify_attestation as _mock_verify_spdx_attestation
 		with ec.oci.blob as mock_ec_oci_spdx_blob
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
+		with data.rule_data__configuration__ as {"signing_identities": {"sbom": _mock_sbom_opts}}
 }
 
 test_ignore_unrelated_sboms if {
@@ -199,6 +203,7 @@ test_cyclonedx_sboms_from_referrers if {
 	]
 	expected := [{"sbom": "from oci blob", "bomFormat": "CycloneDX"}]
 	assertions.assert_equal(sbom.cyclonedx_sboms, expected) with input.attestations as []
+		with sbom._verified_sbom_attestations as []
 		with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
@@ -220,6 +225,7 @@ test_spdx_sboms_from_referrers if {
 	}]
 	expected := [{"sbom": "from oci blob", "SPDXID": "SPDXRef-DOCUMENT"}]
 	assertions.assert_equal(sbom.spdx_sboms, expected) with input.attestations as []
+		with sbom._verified_sbom_attestations as []
 		with input.image as _spdx_image
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
@@ -236,6 +242,7 @@ test_cyclonedx_sboms_from_tag_refs if {
 	]
 	expected := [{"sbom": "from oci blob", "bomFormat": "CycloneDX"}]
 	assertions.assert_equal(sbom.cyclonedx_sboms, expected) with input.attestations as []
+		with sbom._verified_sbom_attestations as []
 		with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as mock_tag_refs
@@ -250,6 +257,7 @@ test_spdx_sboms_from_tag_refs if {
 	mock_tag_refs := ["registry.io/repository/image:sha256-284e3029.sbom"]
 	expected := [{"sbom": "from oci blob", "SPDXID": "SPDXRef-DOCUMENT"}]
 	assertions.assert_equal(sbom.spdx_sboms, expected) with input.attestations as []
+		with sbom._verified_sbom_attestations as []
 		with input.image as _spdx_image
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as mock_tag_refs
@@ -271,6 +279,7 @@ test_no_sboms_from_unrelated_referrers if {
 		"ref": "registry.io/repository/image@sha256:e5f6a7b800000000000000000000000000000000000000000000000e5f6a7b8",
 	}]
 	assertions.assert_equal(sbom.all_sboms, []) with input.attestations as []
+		with sbom._verified_sbom_attestations as []
 		with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
@@ -285,6 +294,7 @@ test_no_sboms_from_non_sbom_tag_refs if {
 		"registry.io/repository/image:sha256-284e3029.att",
 	]
 	assertions.assert_equal(sbom.all_sboms, []) with input.attestations as []
+		with sbom._verified_sbom_attestations as []
 		with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as mock_tag_refs
@@ -545,6 +555,7 @@ test_referrer_sbom_excluded_when_verification_fails if {
 		"ref": "registry.io/repository/image@sha256:a1b2c3d400000000000000000000000000000000000000000000000a1b2c3d4",
 	}]
 	assertions.assert_equal(sbom.all_sboms, []) with input.attestations as []
+		with sbom._verified_sbom_attestations as []
 		with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
@@ -557,6 +568,7 @@ test_referrer_sbom_excluded_when_verification_fails if {
 test_tag_ref_sbom_excluded_when_verification_fails if {
 	mock_tag_refs := ["registry.io/repository/image:sha256-284e3029.sbom"]
 	assertions.assert_equal(sbom.all_sboms, []) with input.attestations as []
+		with sbom._verified_sbom_attestations as []
 		with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as mock_tag_refs
@@ -620,6 +632,7 @@ test_keyless_sbom_verification if {
 	}
 	expected := [{"sbom": "from oci blob", "bomFormat": "CycloneDX"}]
 	assertions.assert_equal(sbom.cyclonedx_sboms, expected) with input.attestations as []
+		with sbom._verified_sbom_attestations as []
 		with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
@@ -628,19 +641,65 @@ test_keyless_sbom_verification if {
 		with data.rule_data__configuration__ as {"signing_identities": {"sbom": keyless_opts}}
 }
 
-# Trusted paths (input.attestations and pipelinerun SBOM_BLOB_URL) are
-# unaffected by the "sbom" signing identity -- they work regardless of whether
-# an identity is configured, since they don't go through the verified wrappers.
-test_trusted_paths_unaffected_by_sbom_opts if {
+test_attestation_sbom_discovered_by_policy_verifier if {
+	expected := ["sbom from attestation"]
+
+	assertions.assert_equal(sbom.cyclonedx_sboms, expected) with input.attestations as []
+		with input.image as _cyclonedx_image
+		with ec.sigstore.verify_attestation as _mock_verify_cyclonedx_attestation
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data__configuration__ as {"signing_identities": {"sbom": _mock_sbom_opts}}
+}
+
+# Attached SBOM attestations are excluded when the "sbom" signing identity is
+# not configured.
+test_attestation_sbom_requires_signing_identity if {
 	attestations := [{"statement": {
 		"predicateType": "https://cyclonedx.org/bom",
 		"predicate": {"bomFormat": "CycloneDX", "from": "attestation"},
 	}}]
 
-	# No "sbom" signing identity configured; trusted path SBOMs still accepted.
-	expected := [{"bomFormat": "CycloneDX", "from": "attestation"}]
+	assertions.assert_empty(sbom.cyclonedx_sboms) with input.attestations as attestations
+		with input.image as _cyclonedx_image
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+}
+
+test_attestation_sbom_signature_verification_failure if {
+	attestations := [{"statement": {
+		"predicateType": "https://spdx.dev/Document",
+		"predicate": {"SPDXID": "SPDXRef-DOCUMENT"},
+	}}]
+
+	assertions.assert_empty(sbom.spdx_sboms) with input.attestations as attestations
+		with input.image as _spdx_image
+		with ec.sigstore.verify_attestation as _mock_verify_attestation_failure
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with data.rule_data__configuration__ as {"signing_identities": {"sbom": _mock_sbom_opts}}
+}
+
+# The digest-pinned SBOM_BLOB_URL in verified provenance remains trusted and
+# does not require the "sbom" signing identity.
+test_pipelinerun_sbom_unaffected_by_sbom_opts if {
+	attestations := [{"statement": {
+		"predicateType": "https://slsa.dev/provenance/v0.2",
+		"predicate": {
+			"buildType": lib.tekton_pipeline_run,
+			"buildConfig": {"tasks": [{"results": [
+				{"name": "IMAGE_DIGEST", "type": "string", "value": "sha256:284e3029000000000000000000000000000000000000000000000000284e3029"}, # regal ignore:line-length
+				{"name": "IMAGE_URL", "type": "string", "value": "registry.io/repository/image:latest"},
+				{"name": "SBOM_BLOB_URL", "type": "string", "value": "registry.io/repository/image@sha256:f0cacc1a"},
+			]}]},
+		},
+	}}]
+
+	expected := [{"sbom": "from oci blob", "bomFormat": "CycloneDX"}]
 	assertions.assert_equal(sbom.cyclonedx_sboms, expected) with input.attestations as attestations
 		with input.image as _cyclonedx_image
+		with ec.oci.blob as mock_ec_oci_cyclonedx_blob
+		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 }
@@ -810,6 +869,30 @@ test_no_verification_errors_when_no_opts if {
 }
 
 _mock_sbom_opts := {"public_key": "test-signing-key", "ignore_rekor": true}
+
+_mock_verify_cyclonedx_attestation(_, _) := {
+	"success": true,
+	"errors": [],
+	"attestations": [{"statement": {
+		"predicateType": "https://cyclonedx.org/bom",
+		"predicate": "sbom from attestation",
+	}}],
+}
+
+_mock_verify_spdx_attestation(_, _) := {
+	"success": true,
+	"errors": [],
+	"attestations": [{"statement": {
+		"predicateType": "https://spdx.dev/Document",
+		"predicate": "sbom from attestation",
+	}}],
+}
+
+_mock_verify_attestation_failure(_, _) := {
+	"success": false,
+	"errors": ["verification failed"],
+	"attestations": [],
+}
 
 _mock_verify_image_success(_, _) := {"errors": []}
 

--- a/policy/lib/sbom/sbom_test.rego
+++ b/policy/lib/sbom/sbom_test.rego
@@ -807,6 +807,7 @@ test_verification_error_surfaced_for_referrers if {
 	errors := sbom.signature_verification_errors with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
+		with ec.sigstore.verify_attestation as _mock_verify_attestation_success
 		with ec.sigstore.verify_image as _mock_verify_image_failure
 		with data.rule_data__configuration__ as {"signing_identities": {"sbom": _mock_sbom_opts}}
 	count(errors) == 1
@@ -819,6 +820,7 @@ test_verification_error_surfaced_for_tag_refs if {
 	errors := sbom.signature_verification_errors with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as mock_tag_refs
+		with ec.sigstore.verify_attestation as _mock_verify_attestation_success
 		with ec.sigstore.verify_image as _mock_verify_image_failure
 		with data.rule_data__configuration__ as {"signing_identities": {"sbom": _mock_sbom_opts}}
 	count(errors) == 1
@@ -839,6 +841,7 @@ test_no_verification_errors_when_verify_succeeds if {
 	errors := sbom.signature_verification_errors with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
+		with ec.sigstore.verify_attestation as _mock_verify_attestation_success
 		with ec.sigstore.verify_image as _mock_verify_image_success
 		with data.rule_data__configuration__ as {"signing_identities": {"sbom": _mock_sbom_opts}}
 	count(errors) == 0
@@ -857,9 +860,21 @@ test_unrelated_referrer_excluded_from_verification_errors if {
 	errors := sbom.signature_verification_errors with input.image as _cyclonedx_image
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
+		with ec.sigstore.verify_attestation as _mock_verify_attestation_success
 		with ec.sigstore.verify_image as _mock_verify_image_failure
 		with data.rule_data__configuration__ as {"signing_identities": {"sbom": _mock_sbom_opts}}
 	count(errors) == 0
+}
+
+test_verification_error_surfaced_for_attestations if {
+	errors := sbom.signature_verification_errors with input.image as _cyclonedx_image
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with ec.sigstore.verify_attestation as _mock_verify_attestation_failure
+		with data.rule_data__configuration__ as {"signing_identities": {"sbom": _mock_sbom_opts}}
+	count(errors) == 1
+	some error in errors
+	contains(error, "SBOM attestation signature verification failed")
 }
 
 test_no_verification_errors_when_no_opts if {
@@ -903,6 +918,12 @@ _mock_verify_spdx_attestation(_, _) := {
 _mock_verify_attestation_failure(_, _) := {
 	"success": false,
 	"errors": ["verification failed"],
+	"attestations": [],
+}
+
+_mock_verify_attestation_success(_, _) := {
+	"success": true,
+	"errors": [],
 	"attestations": [],
 }
 

--- a/policy/release/pre_build_script_task/pre_build_script_task_test.rego
+++ b/policy/release/pre_build_script_task/pre_build_script_task_test.rego
@@ -9,6 +9,7 @@ import data.pre_build_script_task
 test_good_pre_build_script_tasks if {
 	# regal ignore:line-length
 	assertions.assert_empty(pre_build_script_task.deny) with input.attestations as [_good_attestation, _cyclonedx_sbom_attestation]
+		with lib.sbom._verified_sbom_attestations as [_good_attestation, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029000000000000000000000000000000000000000000000000284e3029"} # regal ignore:line-length
@@ -36,6 +37,7 @@ test_good_pre_build_script_tasks if {
 
 	# regal ignore:line-length
 	assertions.assert_empty(pre_build_script_task.deny) with input.attestations as [good_attestation_with_image_index, _cyclonedx_sbom_attestation]
+		with lib.sbom._verified_sbom_attestations as [good_attestation_with_image_index, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 		with ec.oci.descriptor as image_manifest
 		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029000000000000000000000000000000000000000000000000284e3029"} # regal ignore:line-length
@@ -59,6 +61,7 @@ test_disallowed_script_task_runner_image if {
 
 	# regal ignore:line-length
 	assertions.assert_equal_results(expected, pre_build_script_task.deny) with input.attestations as [disallowed_image, _cyclonedx_sbom_attestation]
+		with lib.sbom._verified_sbom_attestations as [disallowed_image, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029000000000000000000000000000000000000000000000000284e3029"} # regal ignore:line-length
@@ -79,6 +82,7 @@ test_pre_build_image_not_in_task_result if {
 
 	# regal ignore:line-length
 	assertions.assert_equal_results(expected, pre_build_script_task.deny) with input.attestations as [attestation_missing_task_result, _cyclonedx_sbom_attestation]
+		with lib.sbom._verified_sbom_attestations as [attestation_missing_task_result, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029000000000000000000000000000000000000000000000000284e3029"} # regal ignore:line-length
@@ -89,6 +93,7 @@ test_pre_build_image_not_in_task_result if {
 test_pre_build_image_in_sbom if {
 	# regal ignore:line-length
 	assertions.assert_empty(pre_build_script_task.deny) with input.attestations as [_good_attestation, _cyclonedx_sbom_attestation]
+		with lib.sbom._verified_sbom_attestations as [_good_attestation, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029000000000000000000000000000000000000000000000000284e3029"} # regal ignore:line-length
@@ -97,6 +102,7 @@ test_pre_build_image_in_sbom if {
 
 	# regal ignore:line-length
 	assertions.assert_empty(pre_build_script_task.deny) with input.attestations as [_good_attestation, _spdx_sbom_attestation]
+		with lib.sbom._verified_sbom_attestations as [_good_attestation, _spdx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029000000000000000000000000000000000000000000000000284e3029"} # regal ignore:line-length
@@ -122,6 +128,7 @@ test_pre_build_image_in_sbom_ignoring_tag if {
 
 	# regal ignore:line-length
 	assertions.assert_empty(pre_build_script_task.deny) with input.attestations as [good_attestation_with_tag_in_image_ref, _cyclonedx_sbom_attestation]
+		with lib.sbom._verified_sbom_attestations as [good_attestation_with_tag_in_image_ref, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029000000000000000000000000000000000000000000000000284e3029"} # regal ignore:line-length
@@ -130,6 +137,7 @@ test_pre_build_image_in_sbom_ignoring_tag if {
 
 	# regal ignore:line-length
 	assertions.assert_empty(pre_build_script_task.deny) with input.attestations as [good_attestation_with_tag_in_image_ref, _spdx_sbom_attestation]
+		with lib.sbom._verified_sbom_attestations as [good_attestation_with_tag_in_image_ref, _spdx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029000000000000000000000000000000000000000000000000284e3029"} # regal ignore:line-length
@@ -151,6 +159,7 @@ test_pre_build_image_not_in_sbom if {
 
 	# regal ignore:line-length
 	assertions.assert_equal_results(expected, pre_build_script_task.deny) with input.attestations as [_good_attestation, incomplete_cyclonedx_sbom_attestation]
+		with lib.sbom._verified_sbom_attestations as [_good_attestation, incomplete_cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029000000000000000000000000000000000000000000000000284e3029"} # regal ignore:line-length
@@ -164,6 +173,7 @@ test_pre_build_image_not_in_sbom if {
 
 	# regal ignore:line-length
 	assertions.assert_equal_results(expected, pre_build_script_task.deny) with input.attestations as [_good_attestation, incomplete_spdx_sbom_attestation]
+		with lib.sbom._verified_sbom_attestations as [_good_attestation, incomplete_spdx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029000000000000000000000000000000000000000000000000284e3029"} # regal ignore:line-length
@@ -186,6 +196,7 @@ test_pre_build_image_reference_is_not_valid if {
 
 	# regal ignore:line-length
 	assertions.assert_equal_results(expected, pre_build_script_task.deny) with input.attestations as [invalid_prebuild_img_attestation, _cyclonedx_sbom_attestation]
+		with lib.sbom._verified_sbom_attestations as [invalid_prebuild_img_attestation, _cyclonedx_sbom_attestation]
 		with data.rule_data.allowed_registry_prefixes as _allowed_registries
 		with ec.oci.descriptor as {"mediaType": "application/vnd.oci.image.manifest.v1+json"}
 		with input.image as {"ref": "registry.io/repository/image@sha256:284e3029000000000000000000000000000000000000000000000000284e3029"} # regal ignore:line-length

--- a/policy/release/rpm_build_deps/rpm_build_deps_test.rego
+++ b/policy/release/rpm_build_deps/rpm_build_deps_test.rego
@@ -15,6 +15,7 @@ import data.rpm_build_deps
 test_valid_download_location_noassertion if {
 	att := _sbom_attestation_with_download_location("NOASSERTION")
 	assertions.assert_empty(rpm_build_deps.warn) with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as _mock_allowed_locations
 }
 
@@ -22,6 +23,7 @@ test_valid_download_location_noassertion if {
 test_valid_download_location_brewroot if {
 	att := _sbom_attestation_with_download_location("https://download.devel.redhat.com/brewroot/repos/some-package.rpm")
 	assertions.assert_empty(rpm_build_deps.warn) with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as _mock_allowed_locations
 }
 
@@ -29,6 +31,7 @@ test_valid_download_location_brewroot if {
 test_valid_download_location_codeload if {
 	att := _sbom_attestation_with_download_location("https://codeload.github.com/user/repo/tar.gz/v1.0.0")
 	assertions.assert_empty(rpm_build_deps.warn) with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as _mock_allowed_locations
 }
 
@@ -36,6 +39,7 @@ test_valid_download_location_codeload if {
 test_valid_download_location_pypi if {
 	att := _sbom_attestation_with_download_location("https://files.pythonhosted.org/packages/some-package-1.0.tar.gz")
 	assertions.assert_empty(rpm_build_deps.warn) with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as _mock_allowed_locations
 }
 
@@ -44,6 +48,7 @@ test_valid_download_location_maven if {
 	location := "https://repo.maven.apache.org/maven2/org/example/artifact/1.0/artifact-1.0.jar"
 	att := _sbom_attestation_with_download_location(location)
 	assertions.assert_empty(rpm_build_deps.warn) with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as _mock_allowed_locations
 }
 
@@ -60,6 +65,7 @@ test_invalid_download_location if {
 		),
 	}}
 	assertions.assert_equal_results(expected, rpm_build_deps.warn) with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as _mock_allowed_locations
 }
 
@@ -71,6 +77,7 @@ test_multiple_packages_all_valid if {
 		"https://codeload.github.com/org/repo/tar.gz/v2.0",
 	])
 	assertions.assert_empty(rpm_build_deps.warn) with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as _mock_allowed_locations
 }
 
@@ -82,6 +89,7 @@ test_multiple_packages_one_invalid if {
 		"https://download.devel.redhat.com/brewroot/repos/package2.rpm",
 	])
 	results := rpm_build_deps.warn with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as _mock_allowed_locations
 	count(results) == 1
 }
@@ -93,6 +101,7 @@ test_multiple_packages_all_invalid if {
 		"https://untrusted2.example.com/package2.rpm",
 	])
 	results := rpm_build_deps.warn with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as _mock_allowed_locations
 	count(results) == 2
 }
@@ -107,6 +116,7 @@ test_empty_sbom if {
 		},
 	}}
 	assertions.assert_empty(rpm_build_deps.warn) with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as _mock_allowed_locations
 }
 
@@ -114,6 +124,7 @@ test_empty_sbom if {
 test_empty_rule_data_warns_urls if {
 	att := _sbom_attestation_with_download_location("https://download.devel.redhat.com/brewroot/repos/package.rpm")
 	results := rpm_build_deps.warn with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as []
 	count(results) == 1
 }
@@ -122,6 +133,7 @@ test_empty_rule_data_warns_urls if {
 test_noassertion_allowed_with_empty_rule_data if {
 	att := _sbom_attestation_with_download_location("NOASSERTION")
 	assertions.assert_empty(rpm_build_deps.warn) with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as []
 }
 
@@ -130,6 +142,7 @@ test_custom_rule_data if {
 	custom_locations := ["^https://custom\\.example\\.com/.*", "^https://archive\\.example\\.org/.*"]
 	att := _sbom_attestation_with_download_location("https://custom.example.com/packages/foo.rpm")
 	assertions.assert_empty(rpm_build_deps.warn) with input.attestations as [att]
+		with data.lib.sbom._verified_sbom_attestations as [att]
 		with data.rule_data.allowed_rpm_build_dependency_sources as custom_locations
 }
 
@@ -168,11 +181,13 @@ test_anchoring_warning_unanchored_pattern if {
 		"severity": "warning",
 	}}
 	assertions.assert_equal_results(expected, rpm_build_deps.deny) with input.attestations as [_sbom_attestation_with_download_location("NOASSERTION")]
+		with data.lib.sbom._verified_sbom_attestations as [_sbom_attestation_with_download_location("NOASSERTION")]
 		with data.rule_data.allowed_rpm_build_dependency_sources as ["download.example.com"]
 }
 
 test_anchoring_warning_anchored_pattern if {
 	assertions.assert_empty(rpm_build_deps.deny) with input.attestations as [_sbom_attestation_with_download_location("NOASSERTION")]
+		with data.lib.sbom._verified_sbom_attestations as [_sbom_attestation_with_download_location("NOASSERTION")]
 		with data.rule_data.allowed_rpm_build_dependency_sources as ["^https://download\\.example\\.com/.*"]
 }
 

--- a/policy/release/sbom/sbom.rego
+++ b/policy/release/sbom/sbom.rego
@@ -58,9 +58,9 @@ deny contains result if {
 # METADATA
 # title: SBOM signature verification failed
 # description: >-
-#   Report when signature verification fails for SBOMs discovered via OCI
-#   referrers or image-tag refs. The SBOM is excluded (fail-closed), but
-#   the user should know why.
+#   Report when signature verification fails for attached SBOM attestations or
+#   SBOMs discovered via OCI referrers or image-tag refs. The SBOM is excluded
+#   (fail-closed), but the user should know why.
 # custom:
 #   short_name: signature_verification
 #   failure_msg: "%s"

--- a/policy/release/sbom/sbom_test.rego
+++ b/policy/release/sbom/sbom_test.rego
@@ -557,6 +557,7 @@ test_sbom_signature_verification_warn if {
 		with input.image.ref as "registry.io/repo/img@sha256:abc123"
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
+		with ec.sigstore.verify_attestation as _mock_verify_attestation_success
 		with ec.sigstore.verify_image as _mock_verify_image_failure
 		with data.rule_data__configuration__ as {"signing_identities": {"sbom": {"public_key": "test-key", "ignore_rekor": true}}}
 }
@@ -576,6 +577,7 @@ test_sbom_signature_verification_no_warn_on_success if {
 		with input.image.ref as "registry.io/repo/img@sha256:abc123"
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
+		with ec.sigstore.verify_attestation as _mock_verify_attestation_success
 		with ec.sigstore.verify_image as _mock_verify_image_success
 		with data.rule_data__configuration__ as {"signing_identities": {"sbom": {"public_key": "test-key", "ignore_rekor": true}}}
 }
@@ -587,6 +589,24 @@ test_sbom_signature_verification_no_warn_without_identity if {
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 }
+
+test_sbom_attestation_signature_verification_warn if {
+	expected := {{
+		"code": "sbom.signature_verification",
+		"msg": "SBOM attestation signature verification failed for registry.io/repo/img@sha256:abc123: verification failed",
+	}}
+	assertions.assert_equal_results(expected, sbom.warn) with input.attestations as []
+		with lib.sbom._verified_sbom_attestations as []
+		with input.image.ref as "registry.io/repo/img@sha256:abc123"
+		with ec.oci.image_referrers as []
+		with ec.oci.image_tag_refs as []
+		with ec.sigstore.verify_attestation as _mock_verify_attestation_failure
+		with data.rule_data__configuration__ as {"signing_identities": {"sbom": {"public_key": "test-key", "ignore_rekor": true}}}
+}
+
+_mock_verify_attestation_success(_, _) := {"success": true, "errors": [], "attestations": []}
+
+_mock_verify_attestation_failure(_, _) := {"success": false, "errors": ["verification failed"], "attestations": []}
 
 _mock_verify_image_success(_, _) := {"errors": []}
 

--- a/policy/release/sbom/sbom_test.rego
+++ b/policy/release/sbom/sbom_test.rego
@@ -9,6 +9,7 @@ import data.sbom
 test_not_found if {
 	expected := {{"code": "sbom.found", "msg": "No SBOM attestations found"}}
 	assertions.assert_equal_results(expected, sbom.deny) with input.attestations as []
+		with lib.sbom._verified_sbom_attestations as []
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
@@ -40,6 +41,7 @@ test_not_found_image_index if {
 	}}
 
 	assertions.assert_empty(sbom.deny) with input.attestations as [att]
+		with lib.sbom._verified_sbom_attestations as [att]
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 		with input.image.ref as "registry.local/ham@sha256:fff0000000000000000000000000000000000000000000000000000000000fff"
@@ -288,16 +290,19 @@ test_rule_data_validation if {
 	}
 
 	assertions.assert_equal_results(sbom.deny, expected) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as d
 
 	# rule data keys are optional
 	assertions.assert_empty(sbom.deny) with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 		with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as {}
 	assertions.assert_empty(sbom.deny) with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 		with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as {
 			lib.sbom.rule_data_packages_key: [],
 			lib.sbom.rule_data_attributes_key: [],
@@ -308,6 +313,7 @@ test_rule_data_validation if {
 	assertions.assert_empty(sbom.deny) with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 		with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as {lib.sbom.rule_data_attributes_key: [{
 			"name": "hermeto:pip:package:binary",
 			"value": "true",
@@ -318,6 +324,7 @@ test_rule_data_validation if {
 test_proxy_rule_data_validation if {
 	# Valid data - no errors
 	assertions.assert_empty(sbom.deny) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as {
 			"proxy_enabled_purl_types": ["maven", "npm"],
 			"allowed_proxy_url_patterns": {"maven": ["^https://proxy\\.example\\.com/.*"]},
@@ -343,6 +350,7 @@ test_proxy_rule_data_validation if {
 		},
 	}
 	assertions.assert_equal_results(expected_bad_purl_types, sbom.deny) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as d_bad_purl_types
 
 	# Invalid allowed_proxy_url_patterns: wrong value type
@@ -357,6 +365,7 @@ test_proxy_rule_data_validation if {
 		"severity": "failure",
 	}}
 	assertions.assert_equal_results(expected_bad_patterns, sbom.deny) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as d_bad_patterns
 
 	# Invalid regex in allowed_proxy_url_patterns
@@ -378,12 +387,14 @@ test_proxy_rule_data_validation if {
 		},
 	}
 	assertions.assert_equal_results(expected_bad_regex, sbom.deny) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as d_bad_regex
 }
 
 test_vendored_purl_types_rule_data_validation if {
 	# Valid data - no errors
 	assertions.assert_empty(sbom.deny) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as {"vendored_purl_types": ["golang", "cargo"]}
 
 	# Invalid vendored_purl_types: wrong type and duplicate
@@ -403,6 +414,7 @@ test_vendored_purl_types_rule_data_validation if {
 		},
 	}
 	assertions.assert_equal_results(expected_bad, sbom.deny) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as d_bad
 }
 
@@ -434,6 +446,7 @@ test_anchoring_warnings_external_references if {
 	}
 
 	assertions.assert_equal_results(expected, sbom.deny) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as d
 }
 
@@ -447,6 +460,7 @@ test_no_anchoring_warning_for_empty_or_absent_url if {
 	# Empty or absent URL should not trigger anchoring warning
 	warnings := {e | some e in sbom.deny; e.severity == "warning"; contains(e.msg, "anchored")}
 	assertions.assert_empty(warnings) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as d
 }
 
@@ -464,6 +478,7 @@ test_anchoring_warnings_package_sources if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom.deny) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as d
 }
 
@@ -481,6 +496,7 @@ test_anchoring_warnings_proxy_url_patterns if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom.deny) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as d
 }
 
@@ -499,6 +515,7 @@ test_anchoring_warnings_except_when if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom.deny) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as d
 }
 
@@ -516,6 +533,7 @@ test_no_anchoring_warnings_when_anchored if {
 	}
 
 	assertions.assert_empty(sbom.deny) with input.attestations as _sbom_attestation
+		with lib.sbom._verified_sbom_attestations as _sbom_attestation
 		with data.rule_data as d
 }
 
@@ -535,6 +553,7 @@ test_sbom_signature_verification_warn if {
 		"msg": "SBOM referrer signature verification failed for registry.io/repo/img@sha256:a1b2c3d400000000000000000000000000000000000000000000000a1b2c3d4: verification failed",
 	}}
 	assertions.assert_equal_results(expected, sbom.warn) with input.attestations as []
+		with lib.sbom._verified_sbom_attestations as []
 		with input.image.ref as "registry.io/repo/img@sha256:abc123"
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
@@ -553,6 +572,7 @@ test_sbom_signature_verification_no_warn_on_success if {
 		"ref": "registry.io/repo/img@sha256:a1b2c3d400000000000000000000000000000000000000000000000a1b2c3d4",
 	}]
 	assertions.assert_empty(sbom.warn) with input.attestations as []
+		with lib.sbom._verified_sbom_attestations as []
 		with input.image.ref as "registry.io/repo/img@sha256:abc123"
 		with ec.oci.image_referrers as mock_referrers
 		with ec.oci.image_tag_refs as []
@@ -562,6 +582,7 @@ test_sbom_signature_verification_no_warn_on_success if {
 
 test_sbom_signature_verification_no_warn_without_identity if {
 	assertions.assert_empty(sbom.warn) with input.attestations as []
+		with lib.sbom._verified_sbom_attestations as []
 		with input.image.ref as "registry.io/repo/img@sha256:abc123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx_test.rego
@@ -8,6 +8,7 @@ import data.sbom_cyclonedx
 
 test_all_good_from_attestation if {
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -32,6 +33,7 @@ test_not_valid if {
 		"value": "spam",
 	}])
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 }
@@ -47,12 +49,14 @@ test_unsupported_version if {
 		"value": "1.3",
 	}])
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 }
 
 test_valid_cdx_1_4 if {
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [_sbom_1_4_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_4_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -69,12 +73,14 @@ test_invalid_cdx_1_4 if {
 		"value": "spam",
 	}])
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 }
 
 test_valid_cdx_1_5 if {
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -91,12 +97,14 @@ test_invalid_cdx_1_5 if {
 		"value": "spam",
 	}])
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 }
 
 test_valid_cdx_1_6 if {
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [_sbom_1_6_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_6_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -113,17 +121,20 @@ test_invalid_cdx_1_6 if {
 		"value": "spam",
 	}])
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 }
 
 test_attributes_not_allowed_all_good if {
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -140,6 +151,7 @@ test_attributes_not_allowed_pair if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -156,6 +168,7 @@ test_attributes_not_allowed_value if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -183,6 +196,7 @@ test_attributes_not_allowed_effective_on if {
 	}
 
 	raw_results := sbom_cyclonedx.deny with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -208,6 +222,7 @@ test_attributes_not_allowed_value_no_purl if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -232,6 +247,7 @@ test_attributes_except_when_match_suppresses_violation if {
 	}])
 
 	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -258,6 +274,7 @@ test_attributes_except_when_no_match_produces_violation if {
 	}])
 
 	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -284,6 +301,7 @@ test_attributes_except_when_missing_qualifier_produces_violation if {
 	}])
 
 	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -310,6 +328,7 @@ test_attributes_except_when_no_purl_produces_violation if {
 	}])
 
 	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -339,6 +358,7 @@ test_attributes_except_when_multiple_patterns if {
 	}])
 
 	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -379,6 +399,7 @@ test_attributes_except_when_without_except_when_unchanged if {
 	])
 
 	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -393,6 +414,7 @@ test_attributes_except_when_without_except_when_unchanged if {
 test_external_references_allowed_regex_with_no_rules_is_allowed if {
 	expected := {}
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -409,6 +431,7 @@ test_external_references_allowed_regex if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -427,6 +450,7 @@ test_external_references_allowed_no_purl if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -446,6 +470,7 @@ test_external_references_disallowed_regex if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -464,6 +489,7 @@ test_external_references_disallowed_no_purl if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [_sbom_1_5_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_1_5_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -524,6 +550,7 @@ test_allowed_package_sources if {
 	])
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 		with data.rule_data as {sbom.rule_data_allowed_package_sources_key: [
@@ -564,6 +591,7 @@ test_allowed_package_sources_no_rule_defined if {
 
 	# rule data is defined only for purl of type generic
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 		with data.rule_data as {sbom.rule_data_allowed_package_sources_key: [{
@@ -579,6 +607,7 @@ test_attributes_not_allowed_no_properties if {
 	}])
 
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -696,6 +725,7 @@ assert_allowed(purl, disallowed_packages) if {
 	}])
 
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [att] # regal ignore:with-outside-test-context
+		with sbom._verified_sbom_attestations as [att]
 		with ec.oci.image_referrers as [] # regal ignore:with-outside-test-context
 		with ec.oci.image_tag_refs as [] # regal ignore:with-outside-test-context
 		with data.rule_data.disallowed_packages as disallowed_packages # regal ignore:with-outside-test-context
@@ -715,6 +745,7 @@ assert_not_allowed(purl, disallowed_packages) if {
 
 	# regal ignore:with-outside-test-context
 	assertions.assert_equal_results(sbom_cyclonedx.deny, expected) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att] # regal ignore:with-outside-test-context
 		with ec.oci.image_referrers as [] # regal ignore:with-outside-test-context
 		with ec.oci.image_tag_refs as [] # regal ignore:with-outside-test-context
 		with data.rule_data.disallowed_packages as disallowed_packages # regal ignore:with-outside-test-context
@@ -838,14 +869,17 @@ _sbom_1_6_attestation := json.patch(_sbom_1_5_attestation, [
 ])
 
 test_proxy_url_cyclonedx_allowed if {
-	results := sbom_cyclonedx.deny with input.attestations as [json.patch(_sbom_1_5_attestation, [{
+	att := json.patch(_sbom_1_5_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/components/-",
 		"value": _cdx_proxy_component(
 			"pkg:maven/org.example/lib@1.0",
 			"https://proxy.example.com/maven/org/example/lib-1.0.jar",
 		),
-	}])]
+	}])
+
+	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -855,14 +889,17 @@ test_proxy_url_cyclonedx_allowed if {
 }
 
 test_proxy_url_cyclonedx_denied if {
-	results := sbom_cyclonedx.deny with input.attestations as [json.patch(_sbom_1_5_attestation, [{
+	att := json.patch(_sbom_1_5_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/components/-",
 		"value": _cdx_proxy_component(
 			"pkg:maven/org.example/lib@1.0",
 			"https://evil.com/lib-1.0.jar",
 		),
-	}])]
+	}])
+
+	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -873,7 +910,7 @@ test_proxy_url_cyclonedx_denied if {
 }
 
 test_proxy_url_cyclonedx_multiple_distribution_refs if {
-	results := sbom_cyclonedx.deny with input.attestations as [json.patch(_sbom_1_5_attestation, [{
+	att := json.patch(_sbom_1_5_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/components/-",
 		"value": {
@@ -886,7 +923,10 @@ test_proxy_url_cyclonedx_multiple_distribution_refs if {
 				{"type": "distribution", "comment": "proxy URL", "url": "https://evil.com/lib-1.0.jar"},
 			],
 		},
-	}])]
+	}])
+
+	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -897,14 +937,17 @@ test_proxy_url_cyclonedx_multiple_distribution_refs if {
 }
 
 test_proxy_url_cyclonedx_empty_enabled_purl_types if {
-	results := sbom_cyclonedx.deny with input.attestations as [json.patch(_sbom_1_5_attestation, [{
+	att := json.patch(_sbom_1_5_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/components/-",
 		"value": _cdx_proxy_component(
 			"pkg:maven/org.example/lib@1.0",
 			"https://evil.com/lib-1.0.jar",
 		),
-	}])]
+	}])
+
+	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -917,14 +960,17 @@ test_proxy_url_cyclonedx_empty_enabled_purl_types if {
 }
 
 test_proxy_url_cyclonedx_enabled_type_no_patterns if {
-	results := sbom_cyclonedx.deny with input.attestations as [json.patch(_sbom_1_5_attestation, [{
+	att := json.patch(_sbom_1_5_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/components/-",
 		"value": _cdx_proxy_component(
 			"pkg:pypi/example-lib@1.0",
 			"https://pypi.org/packages/example-lib-1.0.tar.gz",
 		),
-	}])]
+	}])
+
+	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -938,14 +984,17 @@ test_proxy_url_cyclonedx_enabled_type_no_patterns if {
 }
 
 test_proxy_url_cyclonedx_non_proxy_purl_type if {
-	results := sbom_cyclonedx.deny with input.attestations as [json.patch(_sbom_1_5_attestation, [{
+	att := json.patch(_sbom_1_5_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/components/-",
 		"value": _cdx_proxy_component(
 			"pkg:golang/example.com/lib@1.0",
 			"https://anything.com/lib-1.0.tar.gz",
 		),
-	}])]
+	}])
+
+	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -967,6 +1016,7 @@ test_proxy_url_cyclonedx_not_hermeto_skipped if {
 	}])
 
 	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -986,6 +1036,7 @@ test_proxy_url_cyclonedx_download_url_skipped if {
 	}])
 
 	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1002,6 +1053,7 @@ test_proxy_url_cyclonedx_bundled_skipped if {
 	}])
 
 	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1018,6 +1070,7 @@ test_proxy_metadata_required_cdx_bundled_passes if {
 	}])
 
 	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1084,6 +1137,7 @@ test_proxy_metadata_required_cdx_denied if {
 	}])
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1091,14 +1145,17 @@ test_proxy_metadata_required_cdx_denied if {
 }
 
 test_proxy_metadata_required_cdx_with_distribution_passes if {
-	results := sbom_cyclonedx.deny with input.attestations as [json.patch(_sbom_1_5_attestation, [{
+	att := json.patch(_sbom_1_5_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/components/-",
 		"value": _cdx_hermeto_component(
 			"pkg:maven/org.example/lib@1.0",
 			[{"type": "distribution", "comment": "proxy URL", "url": "https://proxy.example.com/maven/lib-1.0.jar"}],
 		),
-	}])]
+	}])
+
+	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1120,6 +1177,7 @@ test_proxy_metadata_required_cdx_not_hermeto_passes if {
 	}])
 
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1144,6 +1202,7 @@ test_proxy_metadata_required_cdx_non_distribution_refs_denied if {
 	}])
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1158,6 +1217,7 @@ test_proxy_metadata_required_cdx_non_proxy_purl_type_passes if {
 	}])
 
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1175,6 +1235,7 @@ test_proxy_metadata_required_cdx_download_url_passes if {
 	}])
 
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1192,6 +1253,7 @@ test_proxy_metadata_required_cdx_vcs_url_passes if {
 	}])
 
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1222,6 +1284,7 @@ test_experimental_hermeto_backend_cdx_denied if {
 	])
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1243,6 +1306,7 @@ test_experimental_hermeto_backend_cdx_stable_passes if {
 	])
 
 	results := sbom_cyclonedx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1272,6 +1336,7 @@ test_experimental_hermeto_backend_cdx_no_purl_denied if {
 	])
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1302,6 +1367,7 @@ test_experimental_hermeto_backend_cdx_mixed_annotations if {
 	])
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1318,6 +1384,7 @@ test_hermeto_attribution_required_cdx_with_hermeto_passes if {
 	}])
 
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1339,6 +1406,7 @@ test_hermeto_attribution_required_cdx_without_hermeto_denied if {
 	}])
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1367,6 +1435,7 @@ test_hermeto_attribution_required_cdx_mixed if {
 	])
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1381,6 +1450,7 @@ test_hermeto_attribution_required_cdx_unconfigured_type_passes if {
 	}])
 
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1395,6 +1465,7 @@ test_hermeto_attribution_required_cdx_local_dep_passes if {
 	}])
 
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1409,6 +1480,7 @@ test_hermeto_attribution_required_cdx_empty_rule_data_passes if {
 	}])
 
 	assertions.assert_empty(sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1430,6 +1502,7 @@ test_hermeto_attribution_required_cdx_cargo_denied if {
 	}])
 
 	assertions.assert_equal_results(expected, sbom_cyclonedx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []

--- a/policy/release/sbom_spdx/sbom_spdx_test.rego
+++ b/policy/release/sbom_spdx/sbom_spdx_test.rego
@@ -8,6 +8,7 @@ import data.sbom_spdx
 
 test_all_good if {
 	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [_sbom_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -20,6 +21,7 @@ test_all_good_marshaled if {
 		"value": json.marshal(_sbom_attestation.statement.predicate),
 	}])
 	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -33,6 +35,7 @@ test_missing_packages if {
 		"value": [],
 	}])
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -46,6 +49,7 @@ test_missing_files if {
 		"value": [],
 	}])
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -58,6 +62,7 @@ test_digest_mismatch if {
 		"msg": "Image digest in the SBOM, \"sha256:1230000000000000000000000000000000000000000000000000000000000123\", is not as expected, \"sha256:abc0000000000000000000000000000000000000000000000000000000000abc\"",
 	}}
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [_sbom_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_attestation]
 		with input.image.ref as "registry.local/spam@sha256:abc0000000000000000000000000000000000000000000000000000000000abc"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -74,6 +79,7 @@ test_not_valid if {
 		"value": "spam",
 	}])
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 }
@@ -109,6 +115,7 @@ assert_allowed(purl, disallowed_packages) if {
 	}])
 
 	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [att] # regal ignore:with-outside-test-context
+		with sbom._verified_sbom_attestations as [att]
 		with data.rule_data.disallowed_packages as disallowed_packages # regal ignore:with-outside-test-context
 		with data.rule_data.vendored_purl_types as [] # regal ignore:with-outside-test-context
 		with ec.oci.image_referrers as [] # regal ignore:with-outside-test-context
@@ -128,6 +135,7 @@ assert_not_allowed(purl, disallowed_packages) if {
 
 	# regal ignore:with-outside-test-context
 	assertions.assert_equal_results(sbom_spdx.deny, expected) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att] # regal ignore:with-outside-test-context
 		with ec.oci.image_referrers as [] # regal ignore:with-outside-test-context
 		with ec.oci.image_tag_refs as [] # regal ignore:with-outside-test-context
 		with data.rule_data.disallowed_packages as disallowed_packages # regal ignore:with-outside-test-context
@@ -137,6 +145,7 @@ assert_not_allowed(purl, disallowed_packages) if {
 test_external_references_allowed_regex_with_no_rules_is_allowed if {
 	expected := {}
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [_sbom_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -151,6 +160,7 @@ test_external_references_allowed_regex if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [_sbom_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -168,6 +178,7 @@ test_external_references_disallowed_regex if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [_sbom_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -253,6 +264,7 @@ test_allowed_package_sources if {
 	])
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
 		with data.rule_data as {sbom.rule_data_allowed_package_sources_key: [
@@ -277,6 +289,7 @@ test_attributes_not_allowed_pair if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [_sbom_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -293,6 +306,7 @@ test_attributes_not_allowed_value if {
 	}}
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [_sbom_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -320,6 +334,7 @@ test_attributes_not_allowed_effective_on if {
 	}
 
 	raw_results := sbom_spdx.deny with input.attestations as [_sbom_attestation]
+		with sbom._verified_sbom_attestations as [_sbom_attestation]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -363,6 +378,7 @@ test_attributes_multiple_external_refs if {
 	}
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [_sbom]
+		with sbom._verified_sbom_attestations as [_sbom]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -443,6 +459,7 @@ test_attributes_except_when_match_suppresses_violation if {
 	}])
 
 	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -469,6 +486,7 @@ test_attributes_except_when_no_match_produces_violation if {
 	}])
 
 	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -495,6 +513,7 @@ test_attributes_except_when_missing_qualifier_produces_violation if {
 	}])
 
 	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -532,6 +551,7 @@ test_attributes_except_when_no_purl_ref_produces_violation if {
 	}])
 
 	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -576,6 +596,7 @@ test_attributes_except_when_multiple_external_refs if {
 	}])
 
 	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -633,6 +654,7 @@ test_attributes_except_when_without_except_when_unchanged if {
 	])
 
 	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -645,14 +667,17 @@ test_attributes_except_when_without_except_when_unchanged if {
 }
 
 test_proxy_url_spdx_allowed if {
-	results := sbom_spdx.deny with input.attestations as [json.patch(_sbom_attestation, [{
+	att := json.patch(_sbom_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/packages/-",
 		"value": _spdx_proxy_package(
 			"pkg:npm/example-lib@2.0",
 			"https://proxy.example.com/npm/example-lib-2.0.tgz",
 		),
-	}])]
+	}])
+
+	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -662,14 +687,17 @@ test_proxy_url_spdx_allowed if {
 }
 
 test_proxy_url_spdx_denied if {
-	results := sbom_spdx.deny with input.attestations as [json.patch(_sbom_attestation, [{
+	att := json.patch(_sbom_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/packages/-",
 		"value": _spdx_proxy_package(
 			"pkg:npm/example-lib@2.0",
 			"https://evil.com/example-lib-2.0.tgz",
 		),
-	}])]
+	}])
+
+	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -680,14 +708,17 @@ test_proxy_url_spdx_denied if {
 }
 
 test_proxy_url_spdx_empty_source_info_skipped if {
-	results := sbom_spdx.deny with input.attestations as [json.patch(_sbom_attestation, [{
+	att := json.patch(_sbom_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/packages/-",
 		"value": _spdx_proxy_package(
 			"pkg:maven/org.example/lib@1.0",
 			"",
 		),
-	}])]
+	}])
+
+	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -697,14 +728,17 @@ test_proxy_url_spdx_empty_source_info_skipped if {
 }
 
 test_proxy_url_spdx_non_proxy_purl_type if {
-	results := sbom_spdx.deny with input.attestations as [json.patch(_sbom_attestation, [{
+	att := json.patch(_sbom_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/packages/-",
 		"value": _spdx_proxy_package(
 			"pkg:golang/example.com/lib@1.0",
 			"https://anything.com/lib-1.0.tar.gz",
 		),
-	}])]
+	}])
+
+	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -731,6 +765,7 @@ test_proxy_url_spdx_not_hermeto_skipped if {
 	}])
 
 	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -750,6 +785,7 @@ test_proxy_url_spdx_download_url_skipped if {
 	}])
 
 	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -759,14 +795,17 @@ test_proxy_url_spdx_download_url_skipped if {
 }
 
 test_proxy_url_spdx_semicolon_separated if {
-	results := sbom_spdx.deny with input.attestations as [json.patch(_sbom_attestation, [{
+	att := json.patch(_sbom_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/packages/-",
 		"value": _spdx_proxy_package(
 			"pkg:npm/example-lib@2.0",
 			"https://proxy.example.com/npm/example-lib-2.0.tgz;https://evil.com/lib.tgz",
 		),
-	}])]
+	}])
+
+	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -784,6 +823,7 @@ test_proxy_url_spdx_bundled_skipped if {
 	}])
 
 	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -800,6 +840,7 @@ test_proxy_metadata_required_spdx_bundled_passes if {
 	}])
 
 	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -897,6 +938,7 @@ test_proxy_metadata_required_spdx_denied if {
 	}])
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -904,14 +946,17 @@ test_proxy_metadata_required_spdx_denied if {
 }
 
 test_proxy_metadata_required_spdx_with_source_info_passes if {
-	results := sbom_spdx.deny with input.attestations as [json.patch(_sbom_attestation, [{
+	att := json.patch(_sbom_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/packages/-",
 		"value": _spdx_hermeto_package(
 			"pkg:maven/org.example/lib@1.0",
 			"acquired package from proxy https://proxy.example.com/maven/",
 		),
-	}])]
+	}])
+
+	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -940,6 +985,7 @@ test_proxy_metadata_required_spdx_absent_source_info_denied if {
 	}])
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -970,6 +1016,7 @@ test_proxy_metadata_required_spdx_not_hermeto_passes if {
 	}])
 
 	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -984,6 +1031,7 @@ test_proxy_metadata_required_spdx_non_proxy_purl_type_passes if {
 	}])
 
 	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -991,14 +1039,17 @@ test_proxy_metadata_required_spdx_non_proxy_purl_type_passes if {
 }
 
 test_proxy_metadata_required_spdx_download_url_passes if {
-	results := sbom_spdx.deny with input.attestations as [json.patch(_sbom_attestation, [{
+	att := json.patch(_sbom_attestation, [{
 		"op": "add",
 		"path": "/statement/predicate/packages/-",
 		"value": _spdx_hermeto_package(
 			"pkg:maven/org.example/lib@1.0?download_url=https://example.com/lib.jar",
 			"",
 		),
-	}])]
+	}])
+
+	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1018,6 +1069,7 @@ test_proxy_metadata_required_spdx_vcs_url_passes if {
 	}])
 
 	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1041,6 +1093,7 @@ test_experimental_hermeto_backend_spdx_denied if {
 	}])
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1054,6 +1107,7 @@ test_experimental_hermeto_backend_spdx_stable_passes if {
 	}])
 
 	results := sbom_spdx.deny with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1076,6 +1130,7 @@ test_experimental_hermeto_backend_spdx_no_purl_denied if {
 	}])
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1096,6 +1151,7 @@ test_experimental_hermeto_backend_spdx_mixed_annotations if {
 	}])
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1137,6 +1193,7 @@ test_hermeto_attribution_required_spdx_with_hermeto_passes if {
 	}])
 
 	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1158,6 +1215,7 @@ test_hermeto_attribution_required_spdx_without_hermeto_denied if {
 	}])
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1186,6 +1244,7 @@ test_hermeto_attribution_required_spdx_mixed if {
 	])
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1200,6 +1259,7 @@ test_hermeto_attribution_required_spdx_unconfigured_type_passes if {
 	}])
 
 	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1214,6 +1274,7 @@ test_hermeto_attribution_required_spdx_local_dep_passes if {
 	}])
 
 	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1228,6 +1289,7 @@ test_hermeto_attribution_required_spdx_empty_rule_data_passes if {
 	}])
 
 	assertions.assert_empty(sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []
@@ -1249,6 +1311,7 @@ test_hermeto_attribution_required_spdx_cargo_denied if {
 	}])
 
 	assertions.assert_equal_results(expected, sbom_spdx.deny) with input.attestations as [att]
+		with sbom._verified_sbom_attestations as [att]
 		with input.image.ref as "registry.local/spam@sha256:1230000000000000000000000000000000000000000000000000000000000123"
 		with ec.oci.image_referrers as []
 		with ec.oci.image_tag_refs as []


### PR DESCRIPTION
## Summary

- verify attached CycloneDX and SPDX SBOM attestations with signing_identities.sbom
- fail closed when the SBOM signing identity is absent or invalid
- update unit and acceptance coverage for the verified-attestation boundary

## Testing

- make ci

Jira: https://redhat.atlassian.net/browse/EC-2026