### PR TITLE
Push back effective_on dates

### DIFF
--- a/antora/docs/modules/ROOT/pages/packages/release_sbom_cyclonedx.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_sbom_cyclonedx.adoc
@@ -107,7 +107,7 @@ Registry dependencies with a PURL type listed in vendored_purl_types must be pro
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Package %s has PURL type %q which requires Hermeto attribution but was not processed by Hermeto`
 * Code: `sbom_cyclonedx.hermeto_attribution_required`
-* Effective from: `2026-10-01T00:00:00Z`
+* Effective from: `2027-01-15T00:00:00Z`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego#L412[Source, window="_blank"]
 
 [#sbom_cyclonedx__proxy_metadata_required]

--- a/antora/docs/modules/ROOT/pages/packages/release_sbom_spdx.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_sbom_spdx.adoc
@@ -131,7 +131,7 @@ Registry dependencies with a PURL type listed in vendored_purl_types must be pro
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `Package %s has PURL type %q which requires Hermeto attribution but was not processed by Hermeto`
 * Code: `sbom_spdx.hermeto_attribution_required`
-* Effective from: `2026-10-01T00:00:00Z`
+* Effective from: `2027-01-15T00:00:00Z`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/sbom_spdx/sbom_spdx.rego#L408[Source, window="_blank"]
 
 [#sbom_spdx__matches_image]

--- a/antora/docs/modules/ROOT/pages/packages/release_tasks.adoc
+++ b/antora/docs/modules/ROOT/pages/packages/release_tasks.adoc
@@ -42,7 +42,7 @@ Ensure that every currently required test task is included in either the build P
 * Rule type: [rule-type-indicator failure]#FAILURE#
 * FAILURE message: `%s is missing`
 * Code: `tasks.required_test_tasks_found`
-* Effective from: `2026-10-01T00:00:00Z`
+* Effective from: `2027-01-15T00:00:00Z`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L213[Source, window="_blank"]
 
 [#tasks__data_provided]
@@ -79,7 +79,7 @@ Produce a warning when a test task that will be required in the future was not i
 * Rule type: [rule-type-indicator warning]#WARNING#
 * WARNING message: `%s is missing and will be required on %s`
 * Code: `tasks.future_required_test_tasks_found`
-* Effective from: `2026-10-01T00:00:00Z`
+* Effective from: `2027-01-16T00:00:00Z`
 * https://github.com/conforma/policy/blob/{page-origin-refhash}/policy/release/tasks/tasks.rego#L96[Source, window="_blank"]
 
 [#tasks__pinned_task_refs]

--- a/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
+++ b/policy/release/sbom_cyclonedx/sbom_cyclonedx.rego
@@ -432,7 +432,7 @@ deny contains result if {
 #   - redhat
 #   - policy_data
 #   - redhat_security
-#   effective_on: 2026-10-01T00:00:00Z
+#   effective_on: 2027-01-15T00:00:00Z
 deny contains result if {
 	vendored := {t | some t in rule_data.get("vendored_purl_types")}
 

--- a/policy/release/sbom_spdx/sbom_spdx.rego
+++ b/policy/release/sbom_spdx/sbom_spdx.rego
@@ -428,7 +428,7 @@ deny contains result if {
 #   - redhat
 #   - policy_data
 #   - redhat_security
-#   effective_on: 2026-10-01T00:00:00Z
+#   effective_on: 2027-01-15T00:00:00Z
 deny contains result if {
 	vendored := {t | some t in rule_data.get("vendored_purl_types")}
 

--- a/policy/release/tasks/tasks.rego
+++ b/policy/release/tasks/tasks.rego
@@ -109,7 +109,7 @@ warn contains result if {
 #   - redhat_security
 #   depends_on:
 #   - attestation_type.known_attestation_type
-#   effective_on: 2026-10-01T00:00:00Z
+#   effective_on: 2027-01-16T00:00:00Z
 #
 warn contains result if {
 	some required_task in _missing_test_tasks(latest_required_test_tasks.tasks)
@@ -226,7 +226,7 @@ deny contains result if {
 #   - redhat_security
 #   depends_on:
 #   - attestation_type.known_attestation_type
-#   effective_on: 2026-10-01T00:00:00Z
+#   effective_on: 2027-01-15T00:00:00Z
 #
 deny contains result if {
 	some required_task in _missing_test_tasks(current_required_test_tasks.tasks)

--- a/policy/release/tasks/tasks_test.rego
+++ b/policy/release/tasks/tasks_test.rego
@@ -262,7 +262,7 @@ test_required_test_task_missing if {
 
 	assertions.assert_equal_results(expected, matching_denies)
 	some result in matching_denies
-	result.effective_on == "2026-10-01T00:00:00Z"
+	result.effective_on == "2027-01-15T00:00:00Z"
 }
 
 test_future_required_test_task_missing if {
@@ -279,7 +279,7 @@ test_future_required_test_task_missing if {
 
 	assertions.assert_equal_results(expected, matching_warns)
 	some result in matching_warns
-	result.effective_on == "2026-10-01T00:00:00Z"
+	result.effective_on == "2027-01-16T00:00:00Z"
 }
 
 test_current_required_test_task_is_not_also_future_warning if {


### PR DESCRIPTION
Pushing back hermeto attribution since teams are not ready. 

Also pushing back test task enforcement, since the feature won't be delivered until after October.

#### Tickets:
https://redhat.atlassian.net/browse/KONFLUX-14775
